### PR TITLE
[JBEAP-14477] workaround for no physical address for foo, dropping message warnings

### DIFF
--- a/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
+++ b/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
@@ -420,7 +420,9 @@
                     <protocol type="FRAG3"/>
                 </stack>
                 <stack name="tcp">
-                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <transport type="TCP" socket-binding="jgroups-tcp">
+                       <property name="use_ip_addrs">true</property>
+                    </transport>
                     <!-- ##JGROUPS_PING_PROTOCOL## -->
                     <protocol type="MERGE3"/>
                     <protocol type="FD_SOCK"/>


### PR DESCRIPTION
<groups transport: <property name="use_ip_addrs">true</property>