### PR TITLE
CLOUD-1945 - EAP CD merge

### DIFF
--- a/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
+++ b/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
@@ -169,8 +169,8 @@
                 </managed-scheduled-executor-services>
             </concurrent>
             <default-bindings context-service="java:jboss/ee/concurrency/context/default"
-                              <!-- ##DEFAULT_DATASOURCE## -->
-                              ##DEFAULT_JMS##
+                              datasource="##DEFAULT_DATASOURCE##"
+                              jms-connection-factory="##DEFAULT_JMS##"
                               managed-executor-service="java:jboss/ee/concurrency/executor/default"
                               managed-scheduled-executor-service="java:jboss/ee/concurrency/scheduler/default"
                               managed-thread-factory="java:jboss/ee/concurrency/factory/default"/>


### PR DESCRIPTION
This is the EAP CD variant of https://issues.jboss.org/browse/CLOUD-1945 which didn't get merged at the time. This change is needed for the embedded broker removal change.