### PR TITLE
CLOUD-2282 [EAP CD] - match the socket bindings used for JMS etc in eap71

### DIFF
--- a/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
+++ b/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
@@ -597,7 +597,6 @@
         <outbound-socket-binding name="http-messaging">
             <remote-destination host="${jboss.messaging.host:localhost}" port="${jboss.http.port:8080}"/>
         </outbound-socket-binding>
-
         <!-- ##MESSAGING_PORTS## -->
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
+++ b/jboss-eap-cd-openshift-launch/added/standalone-openshift.xml
@@ -580,17 +580,24 @@
         <interface name="private">
             <inet-address value="${jboss.bind.address.private:127.0.0.1}"/>
         </interface>
+        <interface name="bindall">
+            <inet-address value="0.0.0.0"/>
+        </interface>
     </interfaces>
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="0">
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
         <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
-        <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
-        <socket-binding name="http" port="${jboss.http.port:8080}"/>
-        <socket-binding name="https" port="${jboss.https.port:8443}"/>
+        <socket-binding name="ajp" interface="bindall" port="${jboss.ajp.port:8009}"/>
+        <socket-binding name="http" interface="bindall" port="${jboss.http.port:8080}"/>
+        <socket-binding name="https" interface="bindall" port="${jboss.https.port:8443}"/>
         <socket-binding name="jgroups-mping" interface="private" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
         <socket-binding name="jgroups-tcp" interface="private" port="7600"/>
         <socket-binding name="jgroups-udp" interface="private" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
         <socket-binding name="modcluster" multicast-address="${jboss.modcluster.multicast.address:224.0.1.105}" multicast-port="23364"/>
+        <outbound-socket-binding name="http-messaging">
+            <remote-destination host="${jboss.messaging.host:localhost}" port="${jboss.http.port:8080}"/>
+        </outbound-socket-binding>
+
         <!-- ##MESSAGING_PORTS## -->
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>


### PR DESCRIPTION
Since we reverted the embedded broker removal, the socket-bindings shuffled a bit here: https://github.com/jboss-openshift/cct_module/pull/218

This updates the EAP CD standalone-openshift.xml to match.