### PR TITLE
[CLOUD-2706] update JSON logging to capture server boot

### DIFF
--- a/jboss-eap-cd-logging/added/launch/json_logging.sh
+++ b/jboss-eap-cd-logging/added/launch/json_logging.sh
@@ -1,0 +1,15 @@
+function configure() {
+  configure_json_logging
+}
+
+function configure_json_logging() {
+  sed -i "s|^.*\.module=org\.jboss\.logmanager\.ext$||" $LOGGING_FILE
+
+  if [ "${ENABLE_JSON_LOGGING^^}" == "TRUE" ]; then
+    sed -i 's|##CONSOLE-FORMATTER##|OPENSHIFT|' $CONFIG_FILE
+    sed -i 's|##CONSOLE-FORMATTER##|OPENSHIFT|' $LOGGING_FILE
+  else
+    sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $CONFIG_FILE
+    sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $LOGGING_FILE
+  fi
+}

--- a/jboss-eap-cd-logging/configure.sh
+++ b/jboss-eap-cd-logging/configure.sh
@@ -8,3 +8,8 @@ SOURCES_DIR="/tmp/artifacts"
 . $JBOSS_HOME/bin/launch/files.sh
 
 cp -p ${ADDED_DIR}/logging.properties ${JBOSS_HOME}/standalone/configuration/
+mkdir -p ${JBOSS_HOME}/bin/launch/
+
+cp -p ${ADDED_DIR}/launch/json_logging.sh ${JBOSS_HOME}/bin/launch/
+chmod ug+x ${JBOSS_HOME}/bin/launch/json_logging.sh
+

--- a/jboss-eap-logging-ext/added/launch/json_logging.sh
+++ b/jboss-eap-logging-ext/added/launch/json_logging.sh
@@ -1,0 +1,15 @@
+function configure() {
+  configure_json_logging
+}
+
+function configure_json_logging() {
+  sed -i "s|^.*\.module=org\.jboss\.logmanager\.ext$||" $LOGGING_FILE
+
+  if [ "${ENABLE_JSON_LOGGING^^}" == "TRUE" ]; then
+    sed -i 's|##CONSOLE-FORMATTER##|OPENSHIFT|' $CONFIG_FILE
+    sed -i 's|##CONSOLE-FORMATTER##|OPENSHIFT|' $LOGGING_FILE
+  else
+    sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $CONFIG_FILE
+    sed -i 's|##CONSOLE-FORMATTER##|COLOR-PATTERN|' $LOGGING_FILE
+  fi
+}

--- a/jboss-eap-logging-ext/added/logging.properties
+++ b/jboss-eap-logging-ext/added/logging.properties
@@ -42,13 +42,6 @@ formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.COLOR-PATTERN.properties=pattern
 formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
 
-formatter.OPENSHIFT=org.jboss.logmanager.formatters.JsonFormatter
-formatter.OPENSHIFT.properties=keyOverrides,exceptionOutputType,metaData,prettyPrint,printDetails,recordDelimiter
-formatter.OPENSHIFT.constructorProperties=keyOverrides
-formatter.OPENSHIFT.keyOverrides=timestamp\=@timestamp
-formatter.OPENSHIFT.exceptionOutputType=FORMATTED
-formatter.OPENSHIFT.metaData=@version\=1,log-handler\=CONSOLE
-formatter.OPENSHIFT.prettyPrint=false
-formatter.OPENSHIFT.printDetails=false
-formatter.OPENSHIFT.recordDelimiter=\n
-
+formatter.OPENSHIFT=org.jboss.logmanager.ext.formatters.LogstashFormatter
+formatter.OPENSHIFT.properties=metaData
+formatter.OPENSHIFT.metaData=log-handler\=CONSOLE

--- a/jboss-eap-logging-ext/configure.sh
+++ b/jboss-eap-logging-ext/configure.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+SOURCES_DIR="/tmp/artifacts"
+
+. $JBOSS_HOME/bin/launch/files.sh
+
+cp -p ${ADDED_DIR}/logging.properties ${JBOSS_HOME}/standalone/configuration/
+mkdir -p ${JBOSS_HOME}/bin/launch
+
+cp -p ${ADDED_DIR}/launch/json_logging.sh ${JBOSS_HOME}/bin/launch/
+chmod ug+x ${JBOSS_HOME}/bin/launch/json_logging.sh
+
+JBOSS_LOGGING_JAR="$(getfiles org/jboss/logging/main/jboss-logging)"
+JBOSS_LOGGING_DIR="$(dirname $JBOSS_LOGGING_JAR)"
+
+# Location where to install the new module
+# TODO: move to openshift layer
+OPENSHIFT_LAYER_PATH="${JBOSS_HOME}/modules/system/layers/base/org/jboss/logmanager/ext/main/"
+
+mkdir -p $OPENSHIFT_LAYER_PATH
+cp -p ${SOURCES_DIR}/javax.json-1.0.4.jar $OPENSHIFT_LAYER_PATH
+cp -p ${SOURCES_DIR}/jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar $OPENSHIFT_LAYER_PATH
+sed -i 's|org.jboss.logmanager|org.jboss.logmanager.ext|' $JBOSS_LOGGING_DIR/module.xml
+

--- a/jboss-eap-logging-ext/module.yaml
+++ b/jboss-eap-logging-ext/module.yaml
@@ -1,0 +1,14 @@
+schema_version: 1
+name: jboss.eap.logging.ext
+version: '1.0'
+description: EAP logging configuration using logmanager-ext. This is a legacy configuration used by EAP <= 7.1 & EAP 6.x. This module is for legacy support only.
+execute:
+- script: configure.sh
+  user: '185'
+
+artifacts:
+- path: javax.json-1.0.4.jar
+  md5: 569870f975deeeb6691fcb9bc02a9555
+- url: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
+  md5: 3c84f54725ea5657913cf6d1610798b0
+


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2706
Signed-off-by: Ken Wills <kwills@redhat.com>

 - Add new jboss-eap-logging-ext for configuration of JSON logging on EAP <= 7.1 and EAP 6.4