### PR TITLE
[CLOUD-2729] Microprofile Config integration

### DIFF
--- a/jboss-eap-cd-openshift-launch/added/launch/openshift-common.sh
+++ b/jboss-eap-cd-openshift-launch/added/launch/openshift-common.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Common Openshift EAP7 scripts
+
+if [ "${SCRIPT_DEBUG}" = "true" ] ; then
+    set -x
+    echo "Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed"
+fi
+
+CONFIG_FILE=$JBOSS_HOME/standalone/configuration/standalone-openshift.xml
+LOGGING_FILE=$JBOSS_HOME/standalone/configuration/logging.properties
+
+CONFIGURE_SCRIPTS=(
+  $JBOSS_HOME/bin/launch/backward-compatibility.sh
+  $JBOSS_HOME/bin/launch/configure_extensions.sh
+  $JBOSS_HOME/bin/launch/passwd.sh
+  $JBOSS_HOME/bin/launch/messaging.sh
+  $JBOSS_HOME/bin/launch/datasource.sh
+  $JBOSS_HOME/bin/launch/resource-adapter.sh
+  $JBOSS_HOME/bin/launch/admin.sh
+  $JBOSS_HOME/bin/launch/ha.sh
+  $JBOSS_HOME/bin/launch/jgroups.sh
+  $JBOSS_HOME/bin/launch/https.sh
+  $JBOSS_HOME/bin/launch/elytron.sh
+  $JBOSS_HOME/bin/launch/json_logging.sh
+  $JBOSS_HOME/bin/launch/security-domains.sh
+  $JBOSS_HOME/bin/launch/jboss_modules_system_pkgs.sh
+  $JBOSS_HOME/bin/launch/keycloak.sh
+  $JBOSS_HOME/bin/launch/deploymentScanner.sh
+  $JBOSS_HOME/bin/launch/ports.sh
+  $JBOSS_HOME/bin/launch/access_log_valve.sh
+  $JBOSS_HOME/bin/launch/mp-config.sh
+  /opt/run-java/proxy-options
+)

--- a/jboss-eap-cd14-openshift/added/standalone-openshift.xml
+++ b/jboss-eap-cd14-openshift/added/standalone-openshift.xml
@@ -32,6 +32,7 @@
         <extension module="org.wildfly.extension.elytron"/>
         <extension module="org.wildfly.extension.io"/>
         <extension module="org.wildfly.extension.messaging-activemq"/>
+        <extension module="org.wildfly.extension.microprofile.config-smallrye"/>
         <extension module="org.wildfly.extension.microprofile.health-smallrye"/>
         <extension module="org.wildfly.extension.request-controller"/>
         <extension module="org.wildfly.extension.security.manager"/>
@@ -470,6 +471,9 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:messaging-activemq:3.0">
             <!-- ##MESSAGING_SUBSYSTEM_CONFIG## -->
+        </subsystem>
+        <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0">
+            <!-- ##MICROPROFILE_CONFIG_SOURCE## -->
         </subsystem>
         <subsystem xmlns="urn:wildfly:microprofile-health-smallrye:1.0"/>
         <subsystem xmlns="urn:jboss:domain:modcluster:3.0">

--- a/jboss-eap-config-mp_config/added/launch/mp-config.sh
+++ b/jboss-eap-config-mp_config/added/launch/mp-config.sh
@@ -1,0 +1,50 @@
+# Configuration manipulations related to observability of the appserver
+
+if [ -n "${BATS_LOGGING_INCLUDE}" ]; then
+    source "${BATS_LOGGING_INCLUDE}"
+else
+    source $JBOSS_HOME/bin/launch/logging.sh
+fi
+
+
+configure() {
+  configure_microprofile_config_source
+}
+
+configure_microprofile_config_source() {
+
+  local dirConfigSource=$(generate_microprofile_config_source "${MICROPROFILE_CONFIG_DIR}" "${MICROPROFILE_CONFIG_DIR_ORDINAL}")
+
+  if [ -n "$dirConfigSource" ]; then
+    sed -i "s|<!-- ##MICROPROFILE_CONFIG_SOURCE## -->|${dirConfigSource}|" $CONFIG_FILE
+  elif [ -n "${MICROPROFILE_CONFIG_DIR}" ]; then
+    # Invalid MICROPROFILE_CONFIG_DIR -- was not an absolute path.
+    # Since we don't know if the deployment will behave correctly
+    # without this config source we shouldn't start.
+    log_error "Exiting..."
+    exit 1
+  fi
+  
+}
+
+generate_microprofile_config_source() {
+  declare dirName="$1" ordinal="$2"
+
+  local dirConfigSource=""
+
+  if [ -n "$dirName" ]; then
+    if [[ "$dirName" =~ ^/ ]]; then
+      if [ ! -e "$dirName" ]; then
+        log_warning "MICROPROFILE_CONFIG_DIR value '$dirName' is a non-existent path. The server may fail readiness and liveness checks and any config values expected to be derived from the Microprofile Config directory ConfigSource will not be applied."
+      elif [ ! -d "$dirName" ]; then
+        log_warning "MICROPROFILE_CONFIG_DIR value '$dirName' is not a directory. The server may fail readiness and liveness checks and any config values expected to be derived from the Microprofile Config directory ConfigSource will not be applied."
+      fi
+    else
+      log_warning "MICROPROFILE_CONFIG_DIR value '$dirName' is not an absolute path. Use of a relative path is not supported, unpredictable results may occur and behavior may change in future image updates."
+    fi
+    dirConfigSource="<config-source ordinal=\"${ordinal:-500}\" name=\"config-map\"><dir path=\"$dirName\"/></config-source>"
+  fi
+
+  echo $dirConfigSource
+}
+

--- a/jboss-eap-config-mp_config/configure.sh
+++ b/jboss-eap-config-mp_config/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+
+. $JBOSS_HOME/bin/launch/files.sh
+
+mkdir -p ${JBOSS_HOME}/bin/launch/
+
+cp -p ${ADDED_DIR}/launch/mp-config.sh ${JBOSS_HOME}/bin/launch/
+chmod ug+x ${JBOSS_HOME}/bin/launch/mp-config.sh
+

--- a/jboss-eap-config-mp_config/module.yaml
+++ b/jboss-eap-config-mp_config/module.yaml
@@ -1,0 +1,16 @@
+schema_version: 1
+name: jboss.eap.config.mp-config
+version: '1.0'
+description: EAP jboss.eap.config.mp-config script package. Adds configuration related to the Microprofile Config implemenation.
+execute:
+- script: configure.sh
+  user: '185'
+envs:
+    - name: "MICROPROFILE_CONFIG_DIR"
+      example: "/etc/config"
+      description: Absolute path to a directory whose contents should be converted to a Microprofile Config ConfigSource. File names within the directory are converted to configuration keys and the file contents are the associated values. An expected use of this setting would be to mount a ConfigMap to a volume and then use the mount point of that volume as the value for MICROPROFILE_CONFIG_DIR, thus converting the ConfigMap into a ConfigSource.
+    - name: "MICROPROFILE_CONFIG_DIR_ORDINAL"
+      example: "500"
+      description: Ordinal of the Microprofile Config ConfigSource that will be created if MICROPROFILE_CONFIG_DIR is set. The higher the value the higher the precedence of the ConfigSource. The default precedence for the required Microprofile Config system property and environment variable ConfigSources are 400 and 300, respectively.
+      value: "500"
+

--- a/jboss-eap-config-mp_config/test/README.txt
+++ b/jboss-eap-config-mp_config/test/README.txt
@@ -1,0 +1,15 @@
+Tests for Microprofile Config configuration module
+
+Prerequisites:
+
+These tests require libxml2 (for xmllint) and bats
+ $ dnf install libxml2 bats
+
+Running the tests:
+ $ bats test/mp-config.bats
+
+You can get additional output by running:
+ $ bats --tap test/mp-config.bats
+
+ (See the bats manpage for more information.)
+

--- a/jboss-eap-config-mp_config/test/logging.sh
+++ b/jboss-eap-config-mp_config/test/logging.sh
@@ -1,0 +1,17 @@
+function log_warning() {
+  local message="${1}"
+
+  echo >&2 -e "WARN ${message}"
+}
+
+function log_error() {
+  local message="${1}"
+
+  echo >&2 -e "ERROR ${message}"
+}
+
+function log_info() {
+  local message="${1}"
+
+  echo >&2 -e "INFO ${message}"
+}

--- a/jboss-eap-config-mp_config/test/mp-config.bats
+++ b/jboss-eap-config-mp_config/test/mp-config.bats
@@ -1,0 +1,148 @@
+
+# dont enable these by default, bats on CI doesn't output anything if they are set
+#set -euo pipefail
+#IFS=$'\n\t'
+
+# bug in bats with set -eu?
+export BATS_TEST_SKIPPED=
+
+# fake JBOSS_HOME
+export JBOSS_HOME=$BATS_TEST_DIRNAME
+# fake the logger so we don't have to deal with colors
+export BATS_LOGGING_INCLUDE=$BATS_TEST_DIRNAME/logging.sh
+
+load $BATS_TEST_DIRNAME/../added/launch/mp-config.sh
+
+setup() {
+  export CONFIG_FILE=${BATS_TMPDIR}/standalone-openshift.xml
+}
+
+teardown() {
+  if [ -n "${CONFIG_FILE}" ] && [ -f "${CONFIG_FILE}" ]; then
+    rm "${CONFIG_FILE}"
+  fi
+}
+
+@test "Unconfigured" {
+  run generate_microprofile_config_source
+  [ "${output}" = "" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR_ORDINAL=150 -- ordinal only" {
+  run generate_microprofile_config_source "" "150"
+  [ "${output}" = "" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=$BATS_TEST_DIRNAME" {
+
+  run generate_microprofile_config_source "${BATS_TEST_DIRNAME}"
+  echo ${output}
+  [ "$status" -eq 0 ]
+
+  result=$(check_dir_config "${BATS_TEST_DIRNAME}" "500" "${output}")
+  [ -n "${result}" ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=$BATS_TEST_DIRNAME MICROPROFILE_CONFIG_DIR_ORDINAL=150" {
+
+  run generate_microprofile_config_source "${BATS_TEST_DIRNAME}" "150"
+  echo ${output}
+  [ "$status" -eq 0 ]
+
+  result=$(check_dir_config "${BATS_TEST_DIRNAME}" "150" "${output}")
+  [ -n "${result}" ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=etc/config" {
+
+  run generate_microprofile_config_source "etc/config"
+  echo ${output}
+  [ "$status" -eq 0 ]
+
+  echo "${lines[0]}" | grep -q "WARN MICROPROFILE_CONFIG_DIR value 'etc/config' is not an absolute path"
+  [ $? -eq 0 ]
+
+  result=$(check_dir_config "etc/config" "500" "${lines[1]}")
+  [ -n "${result}" ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=jboss.home MICROPROFILE_CONFIG_DIR_ORDINAL=150" {
+
+  run generate_microprofile_config_source "jboss.home" "150"
+  echo ${output}
+  [ "$status" -eq 0 ]
+
+  echo "${lines[0]}" | grep -q "WARN MICROPROFILE_CONFIG_DIR value 'jboss.home' is not an absolute path"
+  [ $? -eq 0 ]
+
+  result=$(check_dir_config "jboss.home" "150" "${lines[1]}")
+  [ -n "${result}" ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=/bogus/beyond/belief" {
+
+  run generate_microprofile_config_source "/bogus/beyond/belief"
+  echo ${output}
+  [ "$status" -eq 0 ]
+
+  echo "${lines[0]}" | grep -q "WARN MICROPROFILE_CONFIG_DIR value '/bogus/beyond/belief' is a non-existent path"
+  [ $? -eq 0 ]
+
+  result=$(check_dir_config "/bogus/beyond/belief" "500" "${lines[1]}")
+  [ -n "${result}" ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=/bogus/beyond/belief MICROPROFILE_CONFIG_DIR_ORDINAL=150" {
+
+  run generate_microprofile_config_source "/bogus/beyond/belief" "150"
+  echo ${output}
+  [ "$status" -eq 0 ]
+
+  echo "${lines[0]}" | grep -q "WARN MICROPROFILE_CONFIG_DIR value '/bogus/beyond/belief' is a non-existent path"
+  [ $? -eq 0 ]
+
+  result=$(check_dir_config "/bogus/beyond/belief" "150" "${lines[1]}")
+  [ -n "${result}" ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=$BATS_LOGGING_INCLUDE" {
+
+  run generate_microprofile_config_source "${BATS_LOGGING_INCLUDE}"
+  echo ${output}
+  [ "$status" -eq 0 ]
+
+  echo "${lines[0]}" | grep "WARN MICROPROFILE_CONFIG_DIR value '${BATS_LOGGING_INCLUDE}' is not a directory"
+  [ $? -eq 0 ]
+
+  result=$(check_dir_config "${BATS_LOGGING_INCLUDE}" "500" "${lines[1]}")
+  [ -n "${result}" ]
+}
+
+@test "Configure MICROPROFILE_CONFIG_DIR=BATS_LOGGING_INCLUDE MICROPROFILE_CONFIG_DIR_ORDINAL=150" {
+
+  run generate_microprofile_config_source "${BATS_LOGGING_INCLUDE}" "150"
+  echo ${output}
+  [ "$status" -eq 0 ]
+  echo "${lines[0]}" | grep -q "WARN MICROPROFILE_CONFIG_DIR value '${BATS_LOGGING_INCLUDE}' is not a directory"
+  [ $? -eq 0 ]
+
+  result=$(check_dir_config "${BATS_LOGGING_INCLUDE}" "150" "${lines[1]}")
+  [ -n "${result}" ]
+}
+
+check_dir_config() {
+  declare dir_name=$1 ordinal=$2 toCheck=$3
+  expected=$(cat <<EOF
+<?xml version="1.0"?>
+   <config-source ordinal="$ordinal" name="config-map"><dir path="$dir_name"/></config-source>
+EOF
+)
+  result=$(echo ${toCheck} | sed 's|\\n||g' | xmllint --format --noblanks -)
+  expected=$(echo "${expected}" | sed 's|\\n||g' | xmllint --format --noblanks -)
+  if [ "${result}" = "${expected}" ]; then
+    echo $result
+  fi
+}
+


### PR DESCRIPTION
Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

https://issues.jboss.org/browse/CLOUD-2729

This introduces a new config script, which won't be available for all EAP7 based images, so I create a new openshift-common.sh.

This impl varies some from the discussion on CLOUD-2729 as I want to keep it simple and require the user to provide an absolute path for MICROPROFILE_CONFIG_DIR.  There's no dir like '/etc/config' available OOTB in our images. A user wanting to mount a ConfigMap for this to use is going to have to specify the absolute dir as part of that mount so they know the path and can readily declare it here.

This will require a separate PR for jboss-eap-7-openshift-image to include the new module.

@jmesnil I also added a MICROPROFILE_CONFIG_DIR_ORDINAL to allow setting the ordinal. In general I would prefer not to do things like that, i.e. I'd rather, in general, that people bring their own config file versus us adding a ton of env vars for myriad settings. But I decided to here. Maybe people want ConfigMap to take precedence over EnvVarConfigSource. (The default 500 value for MICROPROFILE_CONFIG_DIR_ORDINAL means it does). Or maybe they share a ConfigMap among apps and want env vars to take precedence. So I made it configurable but could be talked out of it. :)