### PR TITLE
[CLOUD-2894] Port simple WF 14 changes to standalone-openshift.xml

### DIFF
--- a/jboss-eap-cd-openshift-launch/added/launch/activemq-subsystem.xml
+++ b/jboss-eap-cd-openshift-launch/added/launch/activemq-subsystem.xml
@@ -1,4 +1,5 @@
     <server name="default">
+        <journal pool-files="10"/>
         <security-setting name="#">
             <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
         </security-setting>

--- a/jboss-eap-cd14-openshift/added/standalone-openshift.xml
+++ b/jboss-eap-cd14-openshift/added/standalone-openshift.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
-<server xmlns="urn:jboss:domain:7.0">
+<server xmlns="urn:jboss:domain:8.0">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
@@ -91,7 +91,7 @@
         </access-control>
     </management>
     <profile>
-        <subsystem xmlns="urn:jboss:domain:logging:5.0">
+        <subsystem xmlns="urn:jboss:domain:logging:6.0">
             <console-handler name="CONSOLE">
                 <formatter>
                     <named-formatter name="##CONSOLE-FORMATTER##"/>
@@ -227,7 +227,7 @@
             <log-system-exceptions value="true"/>
             <!-- ##EJB_APPLICATION_SECURITY_DOMAINS## -->
         </subsystem>
-        <subsystem xmlns="urn:wildfly:elytron:3.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+        <subsystem xmlns="urn:wildfly:elytron:4.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
             <providers>
                 <aggregate-providers name="combined-providers">
                     <providers name="elytron"/>
@@ -339,7 +339,7 @@
             <!-- ##TLS## -->
             <!-- ##ELYTRON_TLS## -->
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:infinispan:5.0">
+        <subsystem xmlns="urn:jboss:domain:infinispan:7.0">
             <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
                 <transport lock-timeout="60000"/>
                 <replicated-cache name="default">
@@ -470,19 +470,19 @@
                 <smtp-server outbound-socket-binding-ref="mail-smtp"/>
             </mail-session>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:messaging-activemq:3.0">
+        <subsystem xmlns="urn:jboss:domain:messaging-activemq:4.0">
             <!-- ##MESSAGING_SUBSYSTEM_CONFIG## -->
         </subsystem>
         <subsystem xmlns="urn:wildfly:microprofile-config-smallrye:1.0">
             <!-- ##MICROPROFILE_CONFIG_SOURCE## -->
         </subsystem>
         <subsystem xmlns="urn:wildfly:microprofile-health-smallrye:1.0"/>
-        <subsystem xmlns="urn:jboss:domain:modcluster:3.0">
-            <mod-cluster-config advertise-socket="modcluster" connector="ajp">
+        <subsystem xmlns="urn:jboss:domain:modcluster:4.0">
+            <proxy name="default" advertise-socket="modcluster" listener="ajp">
                 <dynamic-load-provider>
                     <load-metric type="cpu"/>
                 </dynamic-load-provider>
-            </mod-cluster-config>
+            </proxy>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:naming:2.0">
             <!-- ##MESSAGING_REMOTE_BINDINGS## -->
@@ -542,7 +542,7 @@
                 </singleton-policy>
             </singleton-policies>
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:transactions:4.0">
+        <subsystem xmlns="urn:jboss:domain:transactions:5.0">
             <core-environment node-identifier="${jboss.node.name}">
                 <process-id>
                     <uuid/>
@@ -551,7 +551,7 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager" recovery-listener="true"/>
             <!-- ##JDBC_STORE## -->
         </subsystem>
-        <subsystem xmlns="urn:jboss:domain:undertow:6.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other">
+        <subsystem xmlns="urn:jboss:domain:undertow:7.0" default-server="default-server" default-virtual-host="default-host" default-servlet-container="default" default-security-domain="other">
             <buffer-cache name="default"/>
             <server name="default-server">
                 <ajp-listener name="ajp" socket-binding="ajp"/>


### PR DESCRIPTION
Note this does not include the WFLY-10541 change discussed at https://lists.jboss.org/pipermail/wildfly-dev/2018-July/006601.html. That change was to add an expression to the standard WildFly configs to allow the id to be set easily via the command line. The standalone-openshift.xml already supports this with a value of ${jboss.node.name} which will be unique per pod. Changing that to the WFLY-10541 default of ${jboss.tx.node.id:1} will break things as jboss.tx.node.id will not be set and '1' is not an appropriate value.

It also does not include the WFLY-10614 change, which, if confirmed appropriate, will be brought in separately.

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

https://issues.jboss.org/browse/CLOUD-2894