### PR TITLE
CLOUD-2058 - JBoss on Openshift does not start when the java security manager is enabled

### DIFF
--- a/jboss-eap-cd-jolokia/added/standalone.conf
+++ b/jboss-eap-cd-jolokia/added/standalone.conf
@@ -34,4 +34,8 @@ export AB_JOLOKIA_PORT
 # add jolokia options
 JAVA_OPTS="${JAVA_OPTS} $(/opt/jolokia/jolokia-opts)"
 
+if [ "${SECMGR}" = "true" ]; then
+  JAVA_OPTS="$JAVA_OPTS -Dsun.util.logging.disableCallerCheck=true"
+fi
+
 JAVA_OPTS="$JAVA_OPTS -Xbootclasspath/p:${JBOSS_MODULES_JAR}:${JBOSS_LOGMANAGER_JAR}:${JBOSS_JSON_JAR}:${JBOSS_JSON_API_JAR}:${WILDFLY_COMMON_JAR} -Djava.util.logging.manager=org.jboss.logmanager.LogManager"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2058
Signed-off-by: Ken Wills <kwills@redhat.com>