### PR TITLE
[CLOUD-3003] - Move EAP tests from cct_module to jboss-eap-modules repo

### DIFF
--- a/tests/features/6/basic.feature
+++ b/tests/features/6/basic.feature
@@ -1,0 +1,281 @@
+@jboss-eap-6
+Feature: Openshift EAP common tests (EAP and EAP derived images)
+
+  Scenario: Management interface is secured and JAVA_OPTS is modified
+    When container is started with env
+       | variable                    | value             |
+       | ADMIN_USERNAME          | admin2            |
+       | ADMIN_PASSWORD          | lollerskates11$   |
+       | JAVA_OPTS_APPEND            | -Dfoo=bar         |
+    Then container log should contain JBAS015874
+     And run /opt/eap/bin/jboss-cli.sh -c --no-local-auth --user=admin2 --password=lollerskates11$ deployment-info in container and immediately check its output contains activemq-rar
+     # We expect this command to fail, so make sure the return code is zero, we're interested only in output here
+     And run sh -c '/opt/eap/bin/jboss-cli.sh -c --no-local-auth --user=wronguser --password=wrongpass deployment-info || true' in container and immediately check its output contains Authentication failed
+     And container log should contain -Dfoo=bar
+
+  # https://issues.jboss.org/browse/CLOUD-587 (security realm for management API)
+  # CLOUD-834 (probe rework) uses http interface, which cannot use "local" user,
+  #     even when the request originates from localhost, which is how jboss-cli
+  #     works.  Note too that http interface is only bound to localhost.
+  #     setting to @ignore for now.
+  # For EAP 6.4 and derived images
+  @ignore @jboss-eap-6/eap64-openshift @jboss-decisionserver-6 @jboss-processserver-6
+  Scenario: Management interface is secured (no warning message)
+    When container is ready
+    # The below should complete faster than 'should not contain' alone
+    # this is the key for the "JBoss EAP 6.a.b.GA (AS x.y.z.Final-redhat-4) started" message
+    Then container log should contain JBAS015874
+     And available container log should not contain No security realm defined for http management service; all access will be unrestricted.
+
+  # https://issues.jboss.org/browse/CLOUD-587 (security realm for management API)
+  # CLOUD-834 (probe rework) uses http interface, which cannot use "local" user,
+  #     even when the request originates from localhost, which is how jboss-cli
+  #     works.  Note too that http interface is only bound to localhost.
+  #     setting to @ignore for now.
+  # For EAP 7.0 and derived images
+  Scenario: Management interface is secured (no warning message)
+    When container is ready
+    # The below should complete faster than 'should not contain' alone
+    # this is the key for the "JBoss EAP 7.a.b.GA (WildFly Core x.y.z.Final-redhat-1) started" message
+    Then container log should contain WFLYSRV0025
+     And available container log should not contain No security realm defined for http management service; all access will be unrestricted.
+
+  Scenario: Java 1.8 is installed and set as default one
+    When container is ready
+    Then run java -version in container and check its output for openjdk version "1.8.0
+    Then run javac -version in container and check its output for javac 1.8.0
+
+  # test readinessProbe and livenessProbe (CLOUD-612)
+  Scenario: readinessProbe runs successfully
+    When container is ready
+    Then run /opt/eap/bin/readinessProbe.sh in container once
+    Then run /opt/eap/bin/livenessProbe.sh in container once
+
+  # https://issues.jboss.org/browse/CLOUD-204
+  Scenario: Check if kube ping protocol is used by default
+    When container is ready
+    # 2 matches, one for TCP, one for UDP
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='openshift.KUBE_PING']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='protocol'][@type='openshift.DNS_PING']
+
+  # https://issues.jboss.org/browse/CLOUD-1958
+  Scenario: Check if kube ping protocol is used when specified
+    When container is started with env
+      | variable                             | value           |
+      | JGROUPS_PING_PROTOCOL                | openshift.KUBE_PING     |
+    # 2 matches, one for TCP, one for UDP
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='openshift.KUBE_PING']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='protocol'][@type='openshift.DNS_PING']
+
+  # https://issues.jboss.org/browse/CLOUD-1958
+  Scenario: Check if dns ping protocol is used when specified
+    When container is started with env
+      | variable                             | value           |
+      | JGROUPS_PING_PROTOCOL                | openshift.DNS_PING     |
+    # 2 matches, one for TCP, one for UDP
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='openshift.DNS_PING']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='protocol'][@type='openshift.KUBE_PING']
+
+  Scenario: Check if jolokia is configured correctly
+    When container is ready
+    Then container log should contain -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
+
+  Scenario: jgroups-encrypt
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | eap_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //ns:protocol[@type='SYM_ENCRYPT']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /etc/jgroups-encrypt-secret-volume/keystore.jks on XPath //ns:protocol[@type='SYM_ENCRYPT']/ns:property[@name='keystore_name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss on XPath //ns:protocol[@type='SYM_ENCRYPT']/ns:property[@name='alias']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mykeystorepass on XPath //ns:protocol[@type='SYM_ENCRYPT']/ns:property[@name='store_password']
+     # https://issues.jboss.org/browse/CLOUD-1192
+     # https://issues.jboss.org/browse/CLOUD-1196
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for udp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK on XPath //ns:stack[@name='udp']/ns:protocol[@type='SYM_ENCRYPT']/following-sibling::*[1]/@type
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for tcp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK on XPath //ns:stack[@name='tcp']/ns:protocol[@type='SYM_ENCRYPT']/following-sibling::*[1]/@type
+
+  # https://issues.jboss.org/browse/CLOUD-295
+  # https://issues.jboss.org/browse/CLOUD-336
+  Scenario: Check if jgroups is secure
+    When container is started with env
+       | variable                 | value    |
+       | JGROUPS_CLUSTER_PASSWORD | asdfasdf |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='AUTH']
+
+  Scenario: Check jgroups AUTH protocol is disabled when using SYM_ENCRYPT and JGROUPS_CLUSTER_PASSWORD undefined
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='protocol'][@type='AUTH']
+     And container log should contain WARN No password defined for JGroups cluster. AUTH protocol will be disabled. Please define JGROUPS_CLUSTER_PASSWORD.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with encrypt secret undefined
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+    Then container log should contain WARN Detected missing JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with missing name
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with missing password
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with missing keystore dir
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with missing keystore file
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption requires AUTH protocol to be set when using ASYM_ENCRYPT protocol
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+    Then container log should contain WARN No password defined for JGroups cluster. AUTH protocol is required when using JGroups ASYM_ENCRYPT cluster traffic encryption protocol.
+
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_SECRET defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret              |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_NAME defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                   |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_PASSWORD defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                          |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_KEYSTORE_DIR defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume      |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_KEYSTORE file defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                            |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  Scenario: No duplicate module jars
+    When container is ready
+    Then files at /opt/eap/modules/system/layers/openshift/org/jgroups/main should have count of 2
+
+  # Disabling @redhat-sso-7 for now - needs to be adjusted for EAP 7
+  Scenario: Ensure transaction node name is set and we use urandom
+    When container is ready
+    Then container log should contain JBAS015874:
+    And available container log should not contain JBAS010153: Node identifier property is set to the default value. Please make sure it is unique.
+    And available container log should contain -Djava.security.egd
+
+  Scenario: jboss.modules.system.pkgs is set to defaults when JBOSS_MODULES_SYSTEM_PKGS_APPEND env var is not set
+    When container is ready
+    Then container log should contain VM Arguments:
+     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider
+
+  Scenario: jboss.modules.system.pkgs will contain default value and the value of JBOSS_MODULES_SYSTEM_PKGS_APPEND env var, when it is set
+    When container is started with env
+      | variable                             | value           |
+      | JBOSS_MODULES_SYSTEM_PKGS_APPEND     | org.foo.bar     |
+    Then container log should contain VM Arguments:
+     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider,org.foo.bar
+
+  Scenario: check ownership when started as alternative UID
+    When container is started as uid 26458
+    Then container log should contain Running
+     And run id -u in container and check its output contains 26458
+     And all files under /opt/eap are writeable by current user
+     And all files under /deployments are writeable by current user
+
+  Scenario: HTTP proxy as java properties (CLOUD-865) and disable web console (CLOUD-1040)
+    When container is started with env
+      | variable   | value                 |
+      | HTTP_PROXY | http://localhost:1337 |
+    Then container log should contain Admin console is not enabled
+     And container log should contain VM Arguments:
+     And available container log should contain http.proxyHost = localhost
+     And available container log should contain http.proxyPort = 1337
+
+  @ci
+  Scenario: Check that the jboss-eap-6/eap64-openshift image contains 6 layers
+    Given image is built
+     Then image should contain 6 layers
+
+  # https://issues.jboss.org/browse/CLOUD-180
+  Scenario: Check if image version and release is printed on boot
+    When container is ready
+    Then container log should contain Running jboss-eap-6/eap64-openshift image, version
+
+  Scenario: Check that the labels are correctly set
+    Given image is built
+     Then the image should contain label com.redhat.component with value jboss-eap-6-eap64-openshift-container
+      And the image should contain label name with value jboss-eap-6/eap64-openshift
+      And the image should contain label io.openshift.expose-services with value 8080:http
+      And the image should contain label io.openshift.tags with value builder,javaee,eap,eap6
+
+  Scenario: Check for add-user failures
+    When container is ready
+    Then container log should contain Running jboss-eap-6/eap64-openshift image
+     And available container log should not contain AddUserFailedException
+
+  Scenario: CLOUD-437 - ignore MaxPermSize with Java 8
+    When container is ready
+    Then container log should contain JBAS015874
+     And available container log should not contain ignoring option MaxPermSize=256m
+
+  Scenario: CLOUD-237 - DEBUG enabled in standalone.sh
+    When container is ready
+    Then file /opt/eap/bin/standalone.sh should contain DEBUG_MODE="${DEBUG:-false} 
+      And file /opt/eap/bin/standalone.sh should contain DEBUG_PORT="${DEBUG_PORT:-8787}"
+
+  Scenario: CLOUD-1784, make the Access Log Valve configurable
+    When container is started with env
+      | variable          | value                 |
+      | ENABLE_ACCESS_LOG | true                  |
+    Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <valve name="accessLog" module="org.jboss.openshift" class-name="org.jboss.openshift.valves.StdoutAccessLogValve">
+     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <param param-name="pattern" param-value="%h %l %u %t %{X-Forwarded-Host}i &quot;%r&quot; %s %b" />
+     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain </valve>

--- a/tests/features/6/datasource.feature
+++ b/tests/features/6/datasource.feature
@@ -1,0 +1,588 @@
+@jboss-eap-6
+Feature: EAP Openshift datasources
+
+  Scenario: check mysql datasource
+    When container is started with env
+       | variable                  | value            |
+       | DB_SERVICE_PREFIX_MAPPING | test-mysql=TEST |
+       | TEST_DATABASE             | kitchensink      |
+       | TEST_USERNAME             | marek            |
+       | TEST_PASSWORD             | hardtoguess      |
+       | TEST_MYSQL_SERVICE_HOST   | 10.1.1.1         |
+       | TEST_MYSQL_SERVICE_PORT   | 3306             |
+       | TIMER_SERVICE_DATA_STORE  | test-mysql       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_ds on XPath //*[local-name()='timer-service']/@default-data-store
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_ds on XPath //*[local-name()='database-data-store']/@name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='database-data-store']/@database
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_part on XPath //*[local-name()='database-data-store']/@partition
+
+  Scenario: check mysql datasource with advanced settings
+    When container is started with env
+       | variable                  | value                       |
+       | DB_SERVICE_PREFIX_MAPPING | test-mysql=TEST             |
+       | TEST_DATABASE             | kitchensink                 |
+       | TEST_USERNAME             | marek                       |
+       | TEST_PASSWORD             | hardtoguess                 |
+       | TEST_MIN_POOL_SIZE        | 1                           |
+       | TEST_MAX_POOL_SIZE        | 10                          |
+       | TEST_TX_ISOLATION         | TRANSACTION_REPEATABLE_READ |
+       | TEST_MYSQL_SERVICE_HOST   | 10.1.1.1                    |
+       | TEST_MYSQL_SERVICE_PORT   | 3306                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value TRANSACTION_REPEATABLE_READ on XPath //*[local-name()='xa-datasource']/*[local-name()='transaction-isolation']
+
+  Scenario: check mysql datasource with partial advanced settings
+    When container is started with env
+       | variable                  | value                       |
+       | DB_SERVICE_PREFIX_MAPPING | test-mysql=TEST             |
+       | TEST_DATABASE             | kitchensink                 |
+       | TEST_USERNAME             | marek                       |
+       | TEST_PASSWORD             | hardtoguess                 |
+       | TEST_MAX_POOL_SIZE        | 10                          |
+       | TEST_MYSQL_SERVICE_HOST   | 10.1.1.1                    |
+       | TEST_MYSQL_SERVICE_PORT   | 3306                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  # https://issues.jboss.org/browse/CLOUD-508
+  Scenario: check default for timer service datastore
+    When container is ready
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value default-file-store on XPath //*[local-name()='file-data-store']/@name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='timer-service']/*[local-name()='data-stores']
+
+  Scenario: check postgresql datasource
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_DATABASE                 | kitchensink                |
+       | TEST_USERNAME                 | marek                      |
+       | TEST_PASSWORD                 | hardtoguess                |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+       | TIMER_SERVICE_DATA_STORE      | test-postgresql            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_ds on XPath //*[local-name()='timer-service']/@default-data-store
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_ds on XPath //*[local-name()='database-data-store']/@name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value postgresql on XPath //*[local-name()='database-data-store']/@database
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_part on XPath //*[local-name()='database-data-store']/@partition
+
+  Scenario: check postgresql datasource with advanced settings
+    When container is started with env
+       | variable                      | value                       |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST        |
+       | TEST_DATABASE                 | kitchensink                 |
+       | TEST_USERNAME                 | marek                       |
+       | TEST_PASSWORD                 | hardtoguess                 |
+       | TEST_MIN_POOL_SIZE            | 1                           |
+       | TEST_MAX_POOL_SIZE            | 10                          |
+       | TEST_TX_ISOLATION             | TRANSACTION_REPEATABLE_READ |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                    |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value TRANSACTION_REPEATABLE_READ on XPath //*[local-name()='xa-datasource']/*[local-name()='transaction-isolation']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test database type is extracted properly even when name contains a dash (e.g. "eap-app")
+    When container is started with env
+      | variable                         | value                         |
+      | DB_SERVICE_PREFIX_MAPPING        | eap-app-postgresql=TEST       |
+      | TEST_DATABASE                    | kitchensink                   |
+      | TEST_USERNAME                    | marek                         |
+      | TEST_PASSWORD                    | hardtoguess                   |
+      | EAP_APP_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                      |
+      | EAP_APP_POSTGRESQL_SERVICE_PORT  | 5432                          |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/eap_app_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value eap_app_postgresql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: check mysql and postgresql datasource
+    When container is started with env
+       | variable                      | value                                                  |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST_POSTGRESQL,test-mysql=TEST_MYSQL  |
+       | TEST_MYSQL_DATABASE           | kitchensink-m                                          |
+       | TEST_MYSQL_USERNAME           | marek-m                                                |
+       | TEST_MYSQL_PASSWORD           | hardtoguess-m                                          |
+       | TEST_MYSQL_SERVICE_HOST       | 10.1.1.1                                               |
+       | TEST_MYSQL_SERVICE_PORT       | 3306                                                   |
+       | TEST_POSTGRESQL_DATABASE      | kitchensink-p                                          |
+       | TEST_POSTGRESQL_USERNAME      | marek-p                                                |
+       | TEST_POSTGRESQL_PASSWORD      | hardtoguess-p                                          |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.2                                               |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_POSTGRESQL on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink-p on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek-p on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess-p on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_MYSQL on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.2 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink-m on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek-m on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess-m on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: check that exampleDS is generated by default (CLOUD-7)
+    When container is started with env
+       | variable                      | value                                                  |
+       | TIMER_SERVICE_DATA_STORE      | ExampleDS            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ExampleDS on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ExampleDS on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ExampleDS_ds on XPath //*[local-name()='database-data-store']/@name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ExampleDS on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hsql on XPath //*[local-name()='database-data-store']/@database
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ExampleDS_part on XPath //*[local-name()='database-data-store']/@partition
+
+  Scenario: Test warning no username is provided
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_DATABASE                 | kitchensink                |
+       | TEST_PASSWORD                 | hardtoguess                |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+    Then container log should contain WARN The postgresql datasource for TEST service WILL NOT be configured.
+    And container log should contain TEST_PASSWORD: hardtoguess
+
+  Scenario: Test warning on missing database type
+    When container is started with env
+       | variable                      | value                |
+       | DB_SERVICE_PREFIX_MAPPING     | test=TEST            |
+       | TEST_DATABASE                 | kitchensink          |
+       | TEST_USERNAME                 | marek                |
+       | TEST_PASSWORD                 | hardtoguess          |
+       | TEST_SERVICE_HOST             | 10.1.1.1             |
+       | TEST_SERVICE_PORT             | 5432                 |
+    Then container log should contain The mapping does not contain the database type.
+    Then container log should contain WARN The datasource for TEST service WILL NOT be configured.
+
+  Scenario: Test warning on missing driver
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_DATABASE                  | pgdb                                   |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+    Then container log should contain WARN DRIVER not set for datasource TEST. Datasource will not be configured.
+
+  Scenario: Test postgresql xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | postgresql                             |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_DATABASE                  | pgdb                                   |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+       | JDBC_STORE_JNDI_NAME           | java:/jboss/datasources/testds         |
+       | NODE_NAME                      | TestStoreNodeName                      |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pgdb on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='jdbc-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='action']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='communication']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='state']/@table-prefix
+
+  Scenario: Test postgresql non-xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | postgresql                             |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_DATABASE                  | pgdb                                   |
+       | TEST_NONXA                     | true                                   |
+       | TEST_JTA                       | false                                  |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/pgdb on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+
+  Scenario: Test postgresql xa datasource extension w/URL
+    When container is started with env
+       | variable                        | value                                  |
+       | DATASOURCES                     | TEST                                   |
+       | TEST_JNDI                       | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                     | postgresql                             |
+       | TEST_USERNAME                   | tombrady                               |
+       | TEST_PASSWORD                   | password                               |
+       | TEST_XA_CONNECTION_PROPERTY_URL | jdbc:postgresql://10.1.1.1:5432/pgdb   |
+       | TEST_NONXA                      | false                                  |
+       | TEST_JTA                        | true                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/pgdb on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+
+  Scenario: Test mysql xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | mysql                                  |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 3306                                   |
+       | TEST_DATABASE                  | kitchensink                            |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+
+  Scenario: Test mysql non-xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | mysql                                  |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 3306                                   |
+       | TEST_DATABASE                  | kitchensink                            |
+       | TEST_NONXA                     | true                                   |
+       | TEST_JTA                       | false                                  |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/kitchensink on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+
+  Scenario: Test mysql xa datasource extension w/URL
+    When container is started with env
+       | variable                        | value                                  |
+       | DATASOURCES                     | TEST                                   |
+       | TEST_JNDI                       | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                     | mysql                                  |
+       | TEST_USERNAME                   | tombrady                               |
+       | TEST_PASSWORD                   | password                               |
+       | TEST_XA_CONNECTION_PROPERTY_URL | jdbc:mysql://10.1.1.1:3306/kitchensink |
+       | TEST_NONXA                      | false                                  |
+       | TEST_JTA                        | true                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+
+  Scenario: Test external xa datasource extension
+    When container is started with env
+       | variable                          | value                                      |
+       | DATASOURCES                       | TEST                                       |
+       | TEST_JNDI                         | java:/jboss/datasources/testds             |
+       | TEST_DRIVER                       | oracle                                     |
+       | TEST_USERNAME                     | tombrady                                   |
+       | TEST_PASSWORD                     | password                                   |
+       | TEST_XA_CONNECTION_PROPERTY_URL   | jdbc:oracle:thin:@samplehost:1521:oracledb |
+       | TEST_NONXA                        | false                                      |
+       | TEST_JTA                          | true                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:oracle:thin:@samplehost:1521:oracledb on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value oracle on XPath //*[local-name()='xa-datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test external non-xa datasource extension
+    When container is started with env
+       | variable                          | value                                      |
+       | DATASOURCES                       | TEST                                       |
+       | TEST_JNDI                         | java:/jboss/datasources/testds             |
+       | TEST_DRIVER                       | oracle                                     |
+       | TEST_USERNAME                     | tombrady                                   |
+       | TEST_PASSWORD                     | password                                   |
+       | TEST_SERVICE_PORT                 | 1521                                       |
+       | TEST_SERVICE_HOST                 | 10.1.1.1                                   |
+       | TEST_DATABASE                     | oracledb                                   |
+       | TEST_URL                          | jdbc:oracle:thin:@samplehost:1521:oracledb |
+       | TEST_NONXA                        | true                                       |
+       | TEST_JTA                          | false                                      |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:oracle:thin:@samplehost:1521:oracledb on XPath //*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value oracle on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test warning no xa-connection-properties for external xa db
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | oracle                                 |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_DATABASE                  | testdb                                 |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+    Then container log should contain WARN At least one TEST_XA_CONNECTION_PROPERTY_property for datasource TEST is required. Datasource will not be configured.
+
+  Scenario: Test warning no password is provided
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_DATABASE                 | kitchensink                |
+       | TEST_USERNAME                 | marek                      |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+    Then container log should contain WARN The postgresql datasource for TEST service WILL NOT be configured.
+    And container log should contain TEST_JNDI: java:jboss/datasources/test_postgresql
+    And container log should contain TEST_USERNAME: marek
+
+  Scenario: Test warning no database is provided
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_USERNAME                 | marek                      |
+       | TEST_PASSWORD                 | hardtoguess                |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+   Then container log should contain WARN Missing configuration for datasource TEST. TEST_POSTGRESQL_SERVICE_HOST, TEST_POSTGRESQL_SERVICE_PORT, and/or TEST_DATABASE is missing. Datasource will not be configured.
+
+  Scenario: Test warning on wrong mapping
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=MAREK,abc-mysql=DB         |
+       | MAREK_USERNAME                | marek                                      |
+       | MAREK_PASSWORD                | hardtoguess                                |
+   Then container log should contain WARN Missing configuration for datasource MAREK. TEST_POSTGRESQL_SERVICE_HOST, TEST_POSTGRESQL_SERVICE_PORT, and/or MAREK_DATABASE is missing. Datasource will not be configured.
+   And container log should contain In order to configure mysql datasource for DB service you need to provide following environment variables: DB_USERNAME and DB_PASSWORD.
+
+  Scenario: Test warning for missing postgresql xa properties
+    When container is started with env
+       | variable                      | value                      |
+       | DATASOURCES                   | TEST                       |
+       | TEST_USERNAME                 | tombrady                   |
+       | TEST_PASSWORD                 | Need6Rings!                |
+       | TEST_DRIVER                   | postgresql                 |
+    Then container log should contain WARN Missing configuration for XA datasource TEST. Either TEST_XA_CONNECTION_PROPERTY_URL or TEST_XA_CONNECTION_PROPERTY_ServerName, and TEST_XA_CONNECTION_PROPERTY_PortNumber, and TEST_XA_CONNECTION_PROPERTY_DatabaseName is required. Datasource will not be configured.
+
+  Scenario: Test warning for missing mysql xa properties
+    When container is started with env
+       | variable                      | value                      |
+       | DATASOURCES                   | TEST                       |
+       | TEST_USERNAME                 | tombrady                   |
+       | TEST_PASSWORD                 | Need6Rings!                |
+       | TEST_DRIVER                   | mysql                      |
+    Then container log should contain WARN Missing configuration for XA datasource TEST. Either TEST_XA_CONNECTION_PROPERTY_URL or TEST_XA_CONNECTION_PROPERTY_ServerName, and TEST_XA_CONNECTION_PROPERTY_Port, and TEST_XA_CONNECTION_PROPERTY_DatabaseName is required. Datasource will not be configured.
+
+   Scenario: Test multiple datasources with one incorrect
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | pg-postgresql=PG,mysql-mysql=MYSQL         |
+       | PG_USERNAME                   | pguser                                     |
+       | PG_PASSWORD                   | pgpass                                     |
+       | PG_POSTGRESQL_SERVICE_HOST    | 10.1.1.1                                   |
+       | PG_POSTGRESQL_SERVICE_PORT    | 5432                                       |
+       | MYSQL_DATABASE                | kitchensink                                |
+       | MYSQL_USERNAME                | mysqluser                                  |
+       | MYSQL_PASSWORD                | mysqlpass                                  |
+       | MYSQL_MYSQL_SERVICE_HOST      | 10.1.1.1                                   |
+       | MYSQL_MYSQL_SERVICE_PORT      | 3306                                       |
+    Then container log should contain WARN Missing configuration for datasource PG. PG_POSTGRESQL_SERVICE_HOST, PG_POSTGRESQL_SERVICE_PORT, and/or PG_DATABASE is missing. Datasource will not be configured.
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/mysql_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql_mysql-MYSQL on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqluser on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqlpass on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test tx db service mapping w/multiple datasources
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | pg-postgresql=PG,mysql-mysql=MYSQL         |
+       | TX_DATABASE_PREFIX_MAPPING    | mysql-mysql=MYSQL                          |
+       | PG_DATABASE                   | kitchensink                                |
+       | PG_USERNAME                   | pguser                                     |
+       | PG_PASSWORD                   | pgpass                                     |
+       | PG_POSTGRESQL_SERVICE_HOST    | 10.1.1.1                                   |
+       | PG_POSTGRESQL_SERVICE_PORT    | 5432                                       |
+       | MYSQL_DATABASE                | kitchensink                                |
+       | MYSQL_USERNAME                | mysqluser                                  |
+       | MYSQL_PASSWORD                | mysqlpass                                  |
+       | MYSQL_MYSQL_SERVICE_HOST      | 10.1.1.1                                   |
+       | MYSQL_MYSQL_SERVICE_PORT      | 3306                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/mysql_mysqlObjectStore on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql_mysqlObjectStorePool on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/kitchensink on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqluser on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqlpass on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test tx db service mapping w/multiple datasources and tx is first
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | pg-postgresql=PG,mysql-mysql=MYSQL         |
+       | TX_DATABASE_PREFIX_MAPPING    | pg-postgresql=PG                           |
+       | PG_DATABASE                   | kitchensink                                |
+       | PG_USERNAME                   | pguser                                     |
+       | PG_PASSWORD                   | pgpass                                     |
+       | PG_POSTGRESQL_SERVICE_HOST    | 10.1.1.1                                   |
+       | PG_POSTGRESQL_SERVICE_PORT    | 5432                                       |
+       | MYSQL_DATABASE                | kitchensink                                |
+       | MYSQL_USERNAME                | mysqluser                                  |
+       | MYSQL_PASSWORD                | mysqlpass                                  |
+       | MYSQL_MYSQL_SERVICE_HOST      | 10.1.1.1                                   |
+       | MYSQL_MYSQL_SERVICE_PORT      | 3306                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/pg_postgresqlObjectStore on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pg_postgresqlObjectStorePool on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/kitchensink on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value postgresql on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pguser on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pgpass on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test validation's default configuration
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-postgresql=TEST                       |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+      | TEST_POSTGRESQL_SERVICE_HOST      | 10.1.1.1                                   |
+      | TEST_POSTGRESQL_SERVICE_PORT      | 5432                                       |
+      | TEST_NONXA                        | true                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hello on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value world on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='validation']/*[local-name()='validate-on-match']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='background-validation']
+
+  Scenario: Test background-validation configuration with default background-validation-milis
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-postgresql=TEST                       |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+      | TEST_POSTGRESQL_SERVICE_HOST      | 10.1.1.1                                   |
+      | TEST_POSTGRESQL_SERVICE_PORT      | 5432                                       |
+      | TEST_NONXA                        | true                                       |
+      | TEST_BACKGROUND_VALIDATION        | true                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hello on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value world on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='validate-on-match']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='validation']/*[local-name()='background-validation']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10000 on XPath //*[local-name()='validation']/*[local-name()='background-validation-millis']
+
+  Scenario: Test background-validation configuration with custom background-validation-milis value
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-postgresql=TEST                       |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+      | TEST_POSTGRESQL_SERVICE_HOST      | 10.1.1.1                                   |
+      | TEST_POSTGRESQL_SERVICE_PORT      | 5432                                       |
+      | TEST_NONXA                        | true                                       |
+      | TEST_BACKGROUND_VALIDATION        | true                                       |
+      | TEST_BACKGROUND_VALIDATION_MILLIS | 3000                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hello on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value world on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='validate-on-match']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='validation']/*[local-name()='background-validation']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3000 on XPath //*[local-name()='validation']/*[local-name()='background-validation-millis']
+
+  Scenario: Test invalid prefix mapping CLOUD-1743
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-microsoftsql=TEST                     |
+      | TX_SERVICE_PREFIX_MAPPING         | test-microsoftsql=TEST                     |
+      | TEST_JNDI                         | java:/jboss/datasources/testdb             |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+     Then container log should contain WARN DRIVER not set for datasource TEST. Datasource will not be configured.
+     And container log should not contain sed -e expression #1
+
+  Scenario: Test no warning for MongoDB
+    When container is started with env
+      | variable                      | value              |
+      | DB_SERVICE_PREFIX_MAPPING     | eap-app-mongodb=DB |
+      | DB_DATABASE                   | mydb               |
+      | DB_USERNAME                   | root               |
+      | DB_PASSWORD                   | password           |
+      | EAP_APP_MONGODB_SERVICE_HOST  | 10.1.1.1           |
+      | EAP_APP_MONGODB_SERVICE_PORT  | 27017              |
+    Then container log should contain Running jboss-eap-6/eap64-openshift image
+     And available container log should not contain There is a problem with the DB_SERVICE_PREFIX_MAPPING environment variable
+
+  Scenario: CLOUD-2068, test timer datasource refresh-interval, EAP 6.4 should not have refresh-interval
+    When container is started with env
+      | variable                                  | value            |
+      | DB_SERVICE_PREFIX_MAPPING                 | test-mysql=TEST  |
+      | TEST_DATABASE                             | kitchensink      |
+      | TEST_USERNAME                             | marek            |
+      | TEST_PASSWORD                             | hardtoguess      |
+      | TEST_MYSQL_SERVICE_HOST                   | 10.1.1.1         |
+      | TEST_MYSQL_SERVICE_PORT                   | 3306             |
+      | TIMER_SERVICE_DATA_STORE                  | test-mysql       |
+      | TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL | 9999             |
+    Then file /opt/eap/standalone/configuration/standalone-openshift.xml should not contain refresh-interval

--- a/tests/features/6/gc.feature
+++ b/tests/features/6/gc.feature
@@ -1,0 +1,129 @@
+@jboss-eap-6
+Feature: Openshift OpenJDK GC tests
+
+  Scenario: Check default GC configuration
+    When container is ready
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:\+ExitOnOutOfMemoryError\s
+
+  Scenario: Check GC_MIN_HEAP_FREE_RATIO GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_MIN_HEAP_FREE_RATIO           | 5      |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=5\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_MAX_HEAP_FREE_RATIO GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_MAX_HEAP_FREE_RATIO           | 50     |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=50\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_TIME_RATIO GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_TIME_RATIO                    | 5      |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=5\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_ADAPTIVE_SIZE_POLICY_WEIGHT GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_ADAPTIVE_SIZE_POLICY_WEIGHT   | 80     |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=80\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_MAX_METASPACE_SIZE GC configuration
+    When container is started with env
+       | variable                 | value  |
+       | GC_MAX_METASPACE_SIZE    | 120    |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=120m\s
+
+  Scenario: Check for adjusted heap sizes
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 25, "JAVA_INITIAL_MEM_RATIO": 50} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms128m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx256m\s
+
+  # CLOUD-193 (mem-limit); CLOUD-459 (default heap size == max)
+  Scenario: CLOUD-193 Check for dynamic resource allocation
+    When container is started with args
+      | arg                    | value             |
+      | mem_limit              | 1073741824        |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms128m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx512m\s
+
+  # CLOUD-459 (override default heap size)
+  Scenario: CLOUD-459 Check for adjusted default heap size
+    When container is started with args
+      | arg       | value                         |
+      | mem_limit | 1073741824                    |
+      | env_json  | {"INITIAL_HEAP_PERCENT": 0.5} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms256m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx512m\s
+
+  Scenario: CLOUD-1524, test JAVA_CORE_LIMIT
+    When container is started with env
+      | variable              | value    |
+      | JAVA_CORE_LIMIT       | 3        |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=3\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=3\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s
+
+  Scenario: CLOUD-1524, test JAVA_CORE_LIMIT < CONTAINER_CORE_LIMIT
+    When container is started with args and env
+      | arg_env              | value    |
+      | arg_cpu_quota        | 20000    |
+      | arg_cpu_period       | 5000     |
+      | env_JAVA_CORE_LIMIT  | 2        |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=2\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=2\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s
+
+  Scenario: CLOUD-1524, test JAVA_CORE_LIMIT > CONTAINER_CORE_LIMIT
+    When container is started with args and env
+      | arg_env              | value    |
+      | arg_cpu_quota        | 20000    |
+      | arg_cpu_period       | 5000     |
+      | env_JAVA_CORE_LIMIT  | 6        |
+   Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s
+
+  Scenario: CLOUD-1524, test CONTAINER_CORE_LIMIT
+    When container is started with args
+      | arg                  | value    |
+      | cpu_quota            | 20000    |
+      | cpu_period           | 5000     |
+   Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s

--- a/tests/features/6/hawkular.feature
+++ b/tests/features/6/hawkular.feature
@@ -1,0 +1,107 @@
+@jboss-eap-6
+Feature: OpenShift EAP Hawkular agent tests
+
+   Scenario: Check default Hawkular
+     When container is ready
+     Then container log should not contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10 
+
+   # Need to mount an actual keystore to test security-realm configuration
+   @ignore
+   Scenario: Check full Hawkular configuration
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | https://hawkular:5280/hawkular  |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+       | AB_HAWKULAR_REST_FEED_ID            | project:podid                   |
+       | AB_HAWKULAR_REST_TENANT_ID          | project                         |
+       | AB_HAWKULAR_REST_KEYSTORE           | keystore.jks                    |
+       | AB_HAWKULAR_REST_KEYSTORE_DIR       | /etc/hawkular-agent-volume      |
+       | AB_HAWKULAR_REST_KEYSTORE_PASSWORD  | 53same!                         |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+       And container log should contain hawkular.rest.tenantId = project
+       And container log should contain hawkular.rest.feedId = project:podid
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain name: HawkularRealm
+
+   Scenario: Check unsecured Hawkular configuration
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | http://hawkular:5280/hawkular   |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = http://hawkular:5280/hawkular
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain name: HawkularRealm
+
+   Scenario: Check error on Hawkular configuration without keystore
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | https://hawkular:5280/hawkular  |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+       And container log should contain WARN No AB_HAWKULAR_REST_KEYSTORE configuration defined.  HawkularRealm security-realm will not be configured and https access to the Hawkular REST service may fail.
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain name: HawkularRealm
+
+   Scenario: Check error on Hawkular configuration with partial keystore
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | https://hawkular:5280/hawkular  |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+       | AB_HAWKULAR_REST_KEYSTORE           | keystore.jks                    |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+       And container log should contain WARN Partial AB_HAWKULAR_REST_KEYSTORE configuration defined.  HawkularRealm security-realm will not be configured and https access to the Hawkular REST service may fail.
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain name: HawkularRealm
+
+  Scenario: CLOUD-1680 - CTF tests does not test all Hawkular related parameters
+    When container is started with env
+      | variable                                 | value                               |
+      | AB_HAWKULAR_REST_URL                     | https://hawkular:5280/hawkular      |
+      | AB_HAWKULAR_REST_USER                    | hawkW1nd                            |
+      | AB_HAWKULAR_REST_PASSWORD                | QSandC77!                           |
+      | AB_HAWKULAR_REST_KEYSTORE                | keystore.jks                        |
+      | AB_HAWKULAR_REST_KEYSTORE_DIR            | /etc/hawkular-agent-volume          |
+      | AB_HAWKULAR_REST_KEYSTORE_PASSWORD       | 53same!                             |
+      | AB_HAWKULAR_REST_KEYSTORE_TYPE           | pkcs12                              |
+      | AB_HAWKULAR_REST_KEY_MANAGER_ALGORITHM   | SunX509                             |
+      | AB_HAWKULAR_REST_TRUST_MANAGER_ALGORITHM | RSA                                 |
+      | AB_HAWKULAR_REST_SSL_PROTOCOL            | TLSv3                               |
+      | AB_HAWKULAR_AGENT_OPTS                   | delay=100                           |
+    Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=100
+    And container log should contain hawkular.agent.in-container = true
+    And container log should contain hawkular.rest.user = hawkW1nd
+    And container log should contain -Dhawkular.rest.password=QSandC77!
+    And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain keystore-type: pkcs12
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain key-manager-algorithm: SunX509
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain trust-manager-algorithm: RSA
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain ssl-protocol: TLSv3
+
+  Scenario: CLOUD-1680 - test only custom location of agent conf file
+    When container is started with env
+      | variable                                 | value                               |
+      | AB_HAWKULAR_REST_URL                     | https://hawkular:5280/hawkular      |
+      | AB_HAWKULAR_REST_USER                    | hawkW1nd                            |
+      | AB_HAWKULAR_REST_PASSWORD                | QSandC77!                           |
+      | AB_HAWKULAR_AGENT_CONFIG                 | /opt/jboss/container/hawkular-javaagent-config.yaml |
+    Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular-javaagent-config.yaml,delay=10

--- a/tests/features/6/jgroups.feature
+++ b/tests/features/6/jgroups.feature
@@ -1,0 +1,58 @@
+@jboss-eap-6
+Feature: Openshift EAP jgroups secure
+  Scenario: jgroups-encrypt
+    Given XML namespaces
+     | prefix | url                          |
+     | ns     | urn:jboss:domain:jgroups:1.1 |
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | eap_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //ns:protocol[@type='SYM_ENCRYPT']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /etc/jgroups-encrypt-secret-volume/keystore.jks on XPath //ns:protocol[@type='SYM_ENCRYPT']/ns:property[@name='keystore_name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss on XPath //ns:protocol[@type='SYM_ENCRYPT']/ns:property[@name='alias']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mykeystorepass on XPath //ns:protocol[@type='SYM_ENCRYPT']/ns:property[@name='store_password']
+     # https://issues.jboss.org/browse/CLOUD-1188
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for udp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK on XPath //ns:stack[@name='udp']/ns:protocol[@type='SYM_ENCRYPT']/following-sibling::*[1]/@type
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for tcp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK on XPath //ns:stack[@name='tcp']/ns:protocol[@type='SYM_ENCRYPT']/following-sibling::*[1]/@type
+
+  # CLOUD-336
+  Scenario: Check if jgroups is secure
+    Given XML namespaces
+     | prefix | url                          |
+     | ns     | urn:jboss:domain:jgroups:1.1 |
+    When container is started with env
+       | variable                 | value    |
+       | JGROUPS_CLUSTER_PASSWORD | asdfasdf |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //ns:protocol[@type='AUTH']
+
+  Scenario: Check jgroups encryption does not create invalid configuration with missing name
+    Given XML namespaces
+     | prefix | url                            |
+     | ns     | urn:infinispan:server:jgroups:6.1 |
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain JBAS015874:
+    And available container log should contain WARN Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration with missing password
+    Given XML namespaces
+     | prefix | url                            |
+     | ns     | urn:infinispan:server:jgroups:6.1 |
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+    Then container log should contain JBAS015874:
+    And available container log should contain WARN Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.

--- a/tests/features/6/jgroups.feature
+++ b/tests/features/6/jgroups.feature
@@ -42,7 +42,7 @@ Feature: Openshift EAP jgroups secure
        | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
        | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
     Then container log should contain JBAS015874:
-    And available container log should contain WARN Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+    And available container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
 
   Scenario: Check jgroups encryption does not create invalid configuration with missing password
     Given XML namespaces
@@ -55,4 +55,4 @@ Feature: Openshift EAP jgroups secure
        | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
        | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
     Then container log should contain JBAS015874:
-    And available container log should contain WARN Partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+    And available container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.

--- a/tests/features/6/logging.feature
+++ b/tests/features/6/logging.feature
@@ -1,0 +1,17 @@
+@jboss-eap-6
+Feature: Check logging configuration
+
+  Scenario: Check that EAP6 logs are json formatted
+    When container is started with env
+       | variable                    | value             |
+       | ENABLE_JSON_LOGGING         | true              |
+    Then container log should contain "message":"JBAS015874: JBoss EAP 6.4
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value OPENSHIFT on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name
+
+  Scenario: Check that EAP6 logs are normally formatted
+    When container is started with env
+       | variable                    | value              |
+       | ENABLE_JSON_LOGGING         | false              |
+    Then container log should contain JBAS015874: JBoss EAP 6.4
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value COLOR-PATTERN on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name
+

--- a/tests/features/6/logging.feature
+++ b/tests/features/6/logging.feature
@@ -5,13 +5,13 @@ Feature: Check logging configuration
     When container is started with env
        | variable                    | value             |
        | ENABLE_JSON_LOGGING         | true              |
-    Then container log should contain "message":"JBAS015874: JBoss EAP 6.4
+    Then container log should contain "message":"JBAS015874: JBoss EAP 6
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value OPENSHIFT on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name
 
   Scenario: Check that EAP6 logs are normally formatted
     When container is started with env
        | variable                    | value              |
        | ENABLE_JSON_LOGGING         | false              |
-    Then container log should contain JBAS015874: JBoss EAP 6.4
+    Then container log should contain JBAS015874: JBoss EAP 6
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value COLOR-PATTERN on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name
 

--- a/tests/features/6/messaging.feature
+++ b/tests/features/6/messaging.feature
@@ -1,0 +1,102 @@
+@jboss-eap-6
+Feature: Openshift EAP Messaging Tests
+
+  Scenario: Check that RA generated for AMQ
+   Given define variable
+       | variable    | value                                                      |
+       | CONFIG_FILE | /opt/eap/standalone/configuration/standalone-openshift.xml |
+    When container is started with env
+       | variable                     | value             |
+       | MQ_SERVICE_PREFIX_MAPPING    | test-amq=TEST_AMQ |
+       | TEST_AMQ_QUEUES              | in.1,out-1,barq   |
+       | TEST_AMQ_TOPICS              | t.1,t-2.foo,bart  |
+       | TEST_AMQ_USERNAME            | marek             |
+       | TEST_AMQ_PASSWORD            | hardtoguess       |
+       | TEST_AMQ_PROTOCOL            | tcp               |
+       | TEST_AMQ_TCP_SERVICE_HOST    | 10.1.1.1          |
+       | TEST_AMQ_TCP_SERVICE_PORT    | 61616             |
+       | TEST_AMQ_QUEUE_IN_1_JNDI     | java:/queue/in    |
+       | TEST_AMQ_TOPIC_T_2_FOO_JNDI  | java:/topic/foo   |
+       | TEST_AMQ_QUEUE_BARQ_PHYSICAL | MyBarq            |
+       | TEST_AMQ_TOPIC_BART_PHYSICAL | MyBart            |
+    Then container log should contain Bound JCA ConnectionFactory [java:/test-amq/ConnectionFactory]
+    And container log should contain Bound JCA AdminObject [java:/queue/in]
+    And container log should contain Bound JCA AdminObject [java:/queue/out-1]
+    And container log should contain Bound JCA AdminObject [java:/topic/foo]
+    And container log should contain Bound JCA AdminObject [java:/topic/t.1]
+    And file $CONFIG_FILE should contain jndi-name="java:/test-amq/ConnectionFactory"
+    And file $CONFIG_FILE should contain jndi-name="java:/queue/in"
+    And file $CONFIG_FILE should contain jndi-name="java:/queue/out-1"
+    And file $CONFIG_FILE should contain jndi-name="java:/topic/foo"
+    And file $CONFIG_FILE should contain jndi-name="java:/topic/t.1"
+    And file $CONFIG_FILE should contain pool-name="test-amq-ConnectionFactory"
+    And file $CONFIG_FILE should contain pool-name="queue/in.1"
+    And file $CONFIG_FILE should contain pool-name="queue/out-1"
+    And file $CONFIG_FILE should contain pool-name="topic/t.1"
+    And file $CONFIG_FILE should contain pool-name="topic/t-2.foo"
+    And file $CONFIG_FILE should contain pool-name="MyBarq"
+    And file $CONFIG_FILE should contain pool-name="MyBart"
+    And file $CONFIG_FILE should contain <archive>activemq-rar.rar</archive>
+    And file $CONFIG_FILE should contain "ServerUrl">tcp://10.1.1.1:61616?jms.rmIdFromConnectionId=true<
+    And file $CONFIG_FILE should contain "UserName">marek<
+    And file $CONFIG_FILE should contain "Password">hardtoguess<
+    And file $CONFIG_FILE should contain <user-name>marek</user-name>
+    And file $CONFIG_FILE should contain <password>hardtoguess</password>
+    And file $CONFIG_FILE should contain "PhysicalName">queue/in.1<
+    And file $CONFIG_FILE should contain "PhysicalName">queue/out-1<
+    And file $CONFIG_FILE should contain "PhysicalName">topic/t.1<
+    And file $CONFIG_FILE should contain "PhysicalName">topic/t-2.foo<
+    And file $CONFIG_FILE should contain "PhysicalName">MyBarq<
+    And file $CONFIG_FILE should contain "PhysicalName">MyBart<
+
+  # https://issues.jboss.org/browse/CLOUD-329
+  Scenario: Check backwards-compatible RA generated destination names for AMQ
+    When container is started with env
+       | variable                               | value             |
+       | MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION | true              |
+       | MQ_SERVICE_PREFIX_MAPPING              | test-amq=TEST_AMQ |
+       | TEST_AMQ_QUEUES                        | in.1,out-1,barq   |
+       | TEST_AMQ_TOPICS                        | t.1,t-2.foo,bart  |
+       | TEST_AMQ_USERNAME                      | marek             |
+       | TEST_AMQ_PASSWORD                      | hardtoguess       |
+       | TEST_AMQ_PROTOCOL                      | tcp               |
+       | TEST_AMQ_TCP_SERVICE_HOST              | 10.1.1.1          |
+       | TEST_AMQ_TCP_SERVICE_PORT              | 61616             |
+       | TEST_AMQ_QUEUE_BARQ_PHYSICAL           | MyBarq            |
+       | TEST_AMQ_TOPIC_BART_PHYSICAL           | MyBart            |
+    Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain "PhysicalName">in.1<
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain "PhysicalName">out-1<
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain "PhysicalName">t.1<
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain "PhysicalName">t-2.foo<
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain "PhysicalName">MyBarq<
+    And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain "PhysicalName">MyBart<
+
+  Scenario: Check that queues are generated properly for A-MQ resource adapter
+    Given XML namespace ra:urn:jboss:domain:resource-adapters:1.1
+    When container is started with env
+       | variable                    | value                          |
+       | MQ_SERVICE_PREFIX_MAPPING   | test-amq=MQ                    |
+       | TEST_AMQ_TCP_SERVICE_HOST   | 10.1.1.1                       |
+       | TEST_AMQ_TCP_SERVICE_PORT   | 61616                          |
+       | MQ_PROTOCOL                 | tcp                            |
+       | MQ_JNDI                     | java:/jms/AMQConnectionFactory |
+       | MQ_USERNAME                 | openshift                      |
+       | MQ_PASSWORD                 | password                       |
+       | MQ_QUEUES                   | one,two                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQQueue on XPath //ra:resource-adapter[@id="activemq-rar.rar"]//ra:admin-object[@jndi-name="java:/queue/one"]/@class-name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQQueue on XPath //ra:resource-adapter[@id="activemq-rar.rar"]//ra:admin-object[@jndi-name="java:/queue/two"]/@class-name
+
+  Scenario: Check that topics are generated properly for A-MQ resource adapter
+    Given XML namespace ra:urn:jboss:domain:resource-adapters:1.1
+    When container is started with env
+       | variable                    | value                          |
+       | MQ_SERVICE_PREFIX_MAPPING   | test-amq=MQ                    |
+       | TEST_AMQ_TCP_SERVICE_HOST   | 10.1.1.1                       |
+       | TEST_AMQ_TCP_SERVICE_PORT   | 61616                          |
+       | MQ_PROTOCOL                 | tcp                            |
+       | MQ_JNDI                     | java:/jms/AMQConnectionFactory |
+       | MQ_USERNAME                 | openshift                      |
+       | MQ_PASSWORD                 | password                       |
+       | MQ_TOPICS                   | alpha,beta                     |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQTopic on XPath //ra:resource-adapter[@id="activemq-rar.rar"]//ra:admin-object[@jndi-name="java:/topic/alpha"]/@class-name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQTopic on XPath //ra:resource-adapter[@id="activemq-rar.rar"]//ra:admin-object[@jndi-name="java:/topic/beta"]/@class-name

--- a/tests/features/6/resource_adapters.feature
+++ b/tests/features/6/resource_adapters.feature
@@ -1,0 +1,72 @@
+@jboss-eap-6
+Feature: EAP Openshift resource adapters
+
+  Scenario: Test resource adapter extension
+    When container is started with env
+       | variable                         | value                                                        |
+       | RESOURCE_ADAPTERS                | TEST_1                                                       |
+       | TEST_1_ID                        | fileQS                                                       |
+       | TEST_1_MODULE_SLOT               | main                                                         |
+       | TEST_1_MODULE_ID                 | org.jboss.teiid.resource-adapter.file                        |
+       | TEST_1_CONNECTION_CLASS          | org.teiid.resource.adapter.file.FileManagedConnectionFactory |
+       | TEST_1_CONNECTION_JNDI           | java:/marketdata-file                                        |
+       | TEST_1_PROPERTY_ParentDirectory  | /home/jboss/source/injected/injected-files/data              |
+       | TEST_1_PROPERTY_AllowParentPaths | true                                                         |
+       | TEST_1_POOL_MIN_SIZE             | 1                                                            |
+       | TEST_1_POOL_MAX_SIZE             | 5                                                            |
+       | TEST_1_POOL_PREFILL              | false                                                        |
+       | TEST_1_POOL_FLUSH_STRATEGY       | EntirePool                                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value fileQS on XPath //*[local-name()='resource-adapter']/@id
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.jboss.teiid.resource-adapter.file on XPath //*[local-name()='resource-adapter']/*[local-name()='module']/@id
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.teiid.resource.adapter.file.FileManagedConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@class-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /home/jboss/source/injected/injected-files/data on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='config-property'][@name="ParentDirectory"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='prefill']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value EntirePool on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='flush-strategy']
+
+  Scenario: Test warning no module slot is provided
+    When container is started with env
+       | variable                       | value                                                        |
+       | RESOURCE_ADAPTERS              | TEST                                                         |
+       | TEST_CONNECTION_CLASS          | org.teiid.resource.adapter.file.FileManagedConnectionFactory |
+       | TEST_CONNECTION_JNDI           | java:/marketdata-file                                        |
+       | TEST_PROPERTY_ParentDirectory  | /home/jboss/source/injected/injected-files/data              |
+       | TEST_PROPERTY_AllowParentPaths | true                                                         |
+    Then container log should contain WARN TEST_ID is missing from resource adapter configuration, defaulting to TEST
+    And container log should contain WARN TEST_MODULE_SLOT is missing from resource adapter configuration, defaulting to main
+    And container log should contain WARN TEST_MODULE_ID and TEST_ARCHIVE are missing from resource adapter configuration. One is required. Resource adapter will not be configured
+
+   Scenario: Test AMQ resource adapter extension
+    When container is started with env
+       | variable                                | value                                                        |
+       | MQ_SERVICE_PREFIX_MAPPING               | eap-app-amq=DUMMY                                            |
+       | DUMMY_JNDI                              | java:/ConnectionFactory                                      |
+       | RESOURCE_ADAPTERS                       | TEST_1                                                       |
+       | TEST_1_ID                               | activemq-rar.rar                                             |
+       | TEST_1_ARCHIVE                          | activemq-rar.rar                                             |
+       | TEST_1_TRANSACTION_SUPPORT              | XATransaction                                                |
+       | TEST_1_CONNECTION_CLASS                 | org.apache.activemq.ra.ActiveMQManagedConnectionFactory      |
+       | TEST_1_CONNECTION_JNDI                  | java:/ConnectionFactory                                      |
+       | TEST_1_PROPERTY_ServerUrl               | tcp://1.2.3.4:61616?jms.rmIdFromConnectionId=true            |
+       | TEST_1_PROPERTY_UserName                | tombrady                                                     |
+       | TEST_1_PROPERTY_Password                | P@ssword1                                                    |
+       | TEST_1_POOL_XA                          | true                                                         |
+       | TEST_1_POOL_MIN_SIZE                    | 1                                                            |
+       | TEST_1_POOL_MAX_SIZE                    | 5                                                            |
+       | TEST_1_POOL_PREFILL                     | false                                                        |
+       | TEST_1_POOL_IS_SAME_RM_OVERRIDE         | false                                                        |
+       | TEST_1_ADMIN_OBJECTS                    | queue,topic                                                  |
+       | TEST_1_ADMIN_OBJECT_queue_CLASS_NAME    | org.apache.activemq.command.ActiveMQQueue                    |
+       | TEST_1_ADMIN_OBJECT_queue_PHYSICAL_NAME | queue/HELLOWORLDMDBQueue                                     |
+       | TEST_1_ADMIN_OBJECT_topic_CLASS_NAME    | org.apache.activemq.command.ActiveMQTopic                    |
+       | TEST_1_ADMIN_OBJECT_topic_PHYSICAL_NAME | queue/HELLOWORLDMDBTopic                                     |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/@id
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/*[local-name()='archive']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.ra.ActiveMQManagedConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@class-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/ConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='prefill']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='is-same-rm-override']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQTopic on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@class-name

--- a/tests/features/6/s2i.feature
+++ b/tests/features/6/s2i.feature
@@ -1,0 +1,128 @@
+@jboss-eap-6
+Feature: Openshift EAP s2i tests
+  # Always force IPv4 (CLOUD-188)
+  # Append user-supplied arguments (CLOUD-412)
+  # Allow the user to clear down the maven repository after running s2i (CLOUD-413)
+  Scenario: Test to ensure that maven is run with -Djava.net.preferIPv4Stack=true and user-supplied arguments, even when MAVEN_ARGS is overridden, and doesn't clear the local repository after the build
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable          | value                                                                                  |
+       | MAVEN_ARGS        | -e -P jboss-eap-repository-insecure,-securecentral,insecurecentral -DskipTests package |
+       | MAVEN_ARGS_APPEND | -Dfoo=bar                                                                              |
+    Then s2i build log should contain -Djava.net.preferIPv4Stack=true
+    Then s2i build log should contain -Dfoo=bar
+    Then s2i build log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    Then run sh -c 'test -d /tmp/artifacts/m2/org && echo all good' in container and immediately check its output for all good
+
+  # CLOUD-458
+  Scenario: Test s2i build with environment only
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from environment-only
+    Then run sh -c 'echo FOO is $FOO' in container and check its output for FOO is Iedieve8
+    And s2i build log should not contain cp: cannot stat '/tmp/src/*': No such file or directory
+
+  # CLOUD-579
+  Scenario: Test that maven is executed in batch mode
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+    Then s2i build log should contain --batch-mode
+    And s2i build log should not contain \r
+
+  # CLOUD-807
+  Scenario: Test if the container have the JavaScript engine available
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from eap-tests/jsengine
+    Then container log should contain Engine found: jdk.nashorn.api.scripting.NashornScriptEngine
+    And container log should contain Engine class provider found.
+    And container log should not contain JavaScript engine not found.
+
+  # Always force IPv4 (CLOUD-188)
+  # Append user-supplied arguments (CLOUD-412)
+  # Allow the user to clear down the maven repository after running s2i (CLOUD-413)
+  Scenario: Test to ensure that maven is run with -Djava.net.preferIPv4Stack=true and user-supplied arguments, and clears the local repository after the build
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable          | value                      |
+       | MAVEN_ARGS_APPEND | -Dfoo=bar                  |
+       | MAVEN_LOCAL_REPO  | /home/jboss/.m2/repository |
+       | MAVEN_CLEAR_REPO  | true                       |
+    Then s2i build log should contain -Djava.net.preferIPv4Stack=true
+    Then s2i build log should contain -Dfoo=bar
+    Then run sh -c 'test -d /home/jboss/.m2/repository/org && echo oops || echo all good' in container and immediately check its output for all good
+
+  #CLOUD-512: Copy configuration files, after the build has had a chance to generate them.
+  Scenario: custom configuration deployment for existing and dynamically created files
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from eap-dynamic-configuration
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='root-logger']/*[local-name()='level'][@name='DEBUG']
+
+  # CLOUD-1145 - base test
+  Scenario: Check custom war file was successfully deployed via CUSTOM_INSTALL_DIRECTORIES
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from custom-install-directories
+      | variable   | value                    |
+      | CUSTOM_INSTALL_DIRECTORIES | custom   |
+    Then file /opt/eap/standalone/deployments/node-info.war should exist
+
+  # CLOUD-1145 - CSV test
+  Scenario: Check all modules are successfully deployed using comma-separated CUSTOM_INSTALL_DIRECTORIES value
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from custom-install-directories
+      | variable   | value                    |
+      | CUSTOM_INSTALL_DIRECTORIES | foo,bar  |
+    Then file /opt/eap/standalone/deployments/foo.jar should exist
+    Then file /opt/eap/standalone/deployments/bar.jar should exist
+
+  # https://issues.jboss.org/browse/CLOUD-1168
+  Scenario: Make sure that custom data is being copied
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from helloworld-ws
+      | variable    | value                           |
+      | APP_DATADIR | src/main/java/org/jboss/as/quickstarts/wshelloworld |
+    Then file /opt/eap/standalone/data/HelloWorldService.java should exist
+     And file /opt/eap/standalone/data/HelloWorldServiceImpl.java should exist
+     And run stat -c "%a %n" /opt/eap/standalone/data in container and immediately check its output contains 775 /opt/eap/standalone/data
+
+  # https://issues.jboss.org/browse/CLOUD-1143
+  Scenario: Make sure that custom data is being copied even if no source code is found
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from binary
+      | variable    | value                           |
+      | APP_DATADIR | deployments |
+    Then file /opt/eap/standalone/data/node-info.war should exist
+     And run stat -c "%a %n" /opt/eap/standalone/data in container and immediately check its output contains 775 /opt/eap/standalone/data
+
+  Scenario: Make sure SCRIPT_DEBUG triggers set -x in build
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from binary
+      | variable     | value       |
+      | APP_DATADIR  | deployments |
+      | SCRIPT_DEBUG | true        |
+    Then s2i build log should contain + log_info 'Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed'
+
+  # test incremental builds; handles custom module test; custom config test
+  Scenario: Check custom modules and configs are copied in; check incremental builds cache .m2
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable   | value                                                                                  |
+       | MAVEN_ARGS | -e -P jboss-eap-repository-insecure,-securecentral,insecurecentral -DskipTests package |
+    Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <driver name="postgresql94" module="org.postgresql94">
+     And container log should contain JBAS010404: Deploying non-JDBC-compliant driver class org.postgresql.Driver (version 9.4)
+     And s2i build log should contain Downloading:
+     And check that page is served
+        | property | value                        |
+        | path     | /jboss-helloworld/HelloWorld |
+        | port     | 8080                         |
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld with env and incremental
+    Then s2i build log should not contain Downloading:
+
+  # handles binary deployment
+  Scenario: deploys the spring-eap6-quickstart example, then checks if it's deployed.
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from spring-eap6-quickstart
+    Then container log should contain Initializing Spring FrameworkServlet 'jboss-as-kitchensink'
+    Then container log should contain JBAS015859: Deployed "ROOT.war"
+
+  Scenario: deploys the binary example, then checks if both war files are deployed.
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from binary
+    Then container log should contain JBAS015874
+    And available container log should contain JBAS015859: Deployed "node-info.war"
+    And file /opt/eap/standalone/deployments/node-info.war should exist
+    And available container log should contain JBAS015859: Deployed "top-level.war"
+    And file /opt/eap/standalone/deployments/top-level.war should exist
+
+   # test multiple artifacts via ARTIFACT_DIR
+   Scenario: Check custom modules and configs are copied in; check incremental builds cache .m2
+   Given s2i build https://github.com/jboss-developer/jboss-eap-quickstarts from inter-app using 6.4.x
+      | variable   | value                                                                                  |
+      | ARTIFACT_DIR | appA/target,appB/target,shared/target |
+   Then container log should contain JBAS015859: Deployed "jboss-inter-app-shared.jar"
+   Then container log should contain JBAS015859: Deployed "jboss-inter-app-appB.war"
+   Then container log should contain JBAS015859: Deployed "jboss-inter-app-appA.war"

--- a/tests/features/6/security_domains.feature
+++ b/tests/features/6/security_domains.feature
@@ -1,0 +1,94 @@
+@jboss-eap-6
+Feature: EAP Openshift security domains
+
+  Scenario: check security-domain configured
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable           | value       |
+       | SECDOMAIN_NAME | HiThere     |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/roles.properties']
+
+  Scenario: check security-domain unconfigured
+    When container is started with env
+       | variable                  | value       |
+       | UNRELATED_ENV_VARIABLE    | whatever    |
+    Then container log should contain Running jboss-eap-
+     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <!-- no additional security domains configured -->
+    # 3 OOTB are: jboss-web-policy; jboss-ejb-policy; other
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='security-domain']
+
+  Scenario: check security-domain custom user properties
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | SECDOMAIN_NAME              | HiThere               |
+       | SECDOMAIN_USERS_PROPERTIES  | otherusers.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='usersProperties'][@value='${jboss.server.config.dir}/otherusers.properties']
+
+  Scenario: check security-domain custom role properties
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | SECDOMAIN_NAME              | HiThere               |
+       | SECDOMAIN_ROLES_PROPERTIES  | otherroles.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/otherroles.properties']
+
+  # CLOUD-431
+  Scenario: check security-domain custom role and user properties specified as absolute path
+    When container is started with env
+       | variable                        | value                 |
+       | SECDOMAIN_NAME              | HiThere                   |
+       | SECDOMAIN_ROLES_PROPERTIES  | /opt/eap/standalone/configuration/application-roles.properties |
+       | SECDOMAIN_USERS_PROPERTIES  | /opt/eap/standalone/configuration/application-users.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /opt/eap/standalone/configuration/application-roles.properties on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties']/@value
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /opt/eap/standalone/configuration/application-users.properties on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='usersProperties']/@value
+
+  Scenario: check security-domain classic login module
+    When container is started with env
+      | variable                        | value                        |
+      | SECDOMAIN_NAME                  | jdg-openshift                |
+      | SECDOMAIN_USERS_PROPERTIES      | application-users.properties |
+      | SECDOMAIN_ROLES_PROPERTIES      | application-roles.properties |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value UsersRoles on XPath //*[local-name()='security-domain'][@name='jdg-openshift']//*[local-name()='login-module']/@code
+
+  Scenario: check security-domain realm login module
+    When container is started with env
+      | variable                        | value                        |
+      | SECDOMAIN_NAME                  | jdg-openshift                |
+      | SECDOMAIN_LOGIN_MODULE          | RealmUsersRoles              |
+      | SECDOMAIN_USERS_PROPERTIES      | application-users.properties |
+      | SECDOMAIN_ROLES_PROPERTIES      | application-roles.properties |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value RealmUsersRoles on XPath //*[local-name()='security-domain'][@name='jdg-openshift']//*[local-name()='login-module']/@code
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ApplicationRealm on XPath //*[local-name()='security-domain'][@name='jdg-openshift']//*[local-name()='login-module']/*[local-name()='module-option'][@name='realm']/@value
+
+  Scenario: check security-domain configured with prefix
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable           | value       |
+       | EAP_SECDOMAIN_NAME | HiThere     |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/roles.properties']
+
+  Scenario: check security-domain unconfigured with prefix
+    When container is started with env
+       | variable                  | value       |
+       | UNRELATED_ENV_VARIABLE    | whatever    |
+    Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <!-- no additional security domains configured -->
+    # 3 OOTB are: jboss-web-policy; jboss-ejb-policy; other
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='security-domain']
+
+  Scenario: check security-domain custom user properties with prefix
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | EAP_SECDOMAIN_NAME              | HiThere               |
+       | EAP_SECDOMAIN_USERS_PROPERTIES  | otherusers.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='usersProperties'][@value='${jboss.server.config.dir}/otherusers.properties']
+
+  Scenario: check security-domain custom role properties with prefix
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | EAP_SECDOMAIN_NAME              | HiThere               |
+       | EAP_SECDOMAIN_ROLES_PROPERTIES  | otherroles.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/otherroles.properties']

--- a/tests/features/6/sso.feature
+++ b/tests/features/6/sso.feature
@@ -1,0 +1,79 @@
+@jboss-eap-6
+Feature: OpenShift EAP SSO tests
+
+   Scenario: Check default keycloak config
+     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts using 7.0.x-ose
+       | variable               | value                                                                     |
+       | ARTIFACT_DIR           | app-jee-jsp/target,service-jee-jaxrs/target,app-profile-jee-jsp/target,app-profile-saml-jee-jsp/target    |
+       | SSO_REALM              | demo                                                                      |
+       | SSO_PUBLIC_KEY         | MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiLezsNQtZSaJvNZXTmjhlpIJnnwgGL5R1vkPLdt7odMgDzLHQ1h4DlfJPuPI4aI8uo8VkSGYQXWaOGUh3YJXtdO1vcym1SuP8ep6YnDy9vbUibA/o8RW6Wnj3Y4tqShIfuWf3MEsiH+KizoIJm6Av7DTGZSGFQnZWxBEZ2WUyFt297aLWuVM0k9vHMWSraXQo78XuU3pxrYzkI+A4QpeShg8xE7mNrs8g3uTmc53KR45+wW1icclzdix/JcT6YaSgLEVrIR9WkkYfEGj3vSrOzYA46pQe6WQoenLKtIDFmFDPjhcPoi989px9f+1HCIYP0txBS/hnJZaPdn5/lEUKQIDAQAB  |
+       | SSO_URL                | http://localhost:8080/auth    |
+    Then container log should contain Deployed "service.war"
+    And container log should contain Deployed "app-profile-jsp.war"
+    And container log should contain Deployed "app-jsp.war"
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value demo on XPath //*[local-name()='realm']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-cors']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='bearer-only']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-basic-auth'] 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value http://localhost:8080/auth on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='auth-server-url']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value service.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@entityID
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value EXTERNAL on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@sslPolicy
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value / on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@logoutPage    
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='Keys']/*[local-name()='Key']/@signing 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value idp on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='IDP']/@entityID 
+     
+  Scenario: Check custom keycloak config
+     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts using 7.0.x-ose
+       | variable               | value                                                                     |
+       | ARTIFACT_DIR           | app-jee-jsp/target,service-jee-jaxrs/target,app-profile-jee-jsp/target,app-profile-saml-jee-jsp/target    |
+       | SSO_REALM              | demo                                                                      |
+       | SSO_PUBLIC_KEY         | MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiLezsNQtZSaJvNZXTmjhlpIJnnwgGL5R1vkPLdt7odMgDzLHQ1h4DlfJPuPI4aI8uo8VkSGYQXWaOGUh3YJXtdO1vcym1SuP8ep6YnDy9vbUibA/o8RW6Wnj3Y4tqShIfuWf3MEsiH+KizoIJm6Av7DTGZSGFQnZWxBEZ2WUyFt297aLWuVM0k9vHMWSraXQo78XuU3pxrYzkI+A4QpeShg8xE7mNrs8g3uTmc53KR45+wW1icclzdix/JcT6YaSgLEVrIR9WkkYfEGj3vSrOzYA46pQe6WQoenLKtIDFmFDPjhcPoi989px9f+1HCIYP0txBS/hnJZaPdn5/lEUKQIDAQAB  |
+       | SSO_URL                | http://localhost:8080/auth    |
+       | SSO_ENABLE_CORS        | true                          |
+       | SSO_BEARER_ONLY        | true                          |
+       | SSO_SAML_LOGOUT_PAGE   | /tombrady                     |
+    Then container log should contain Deployed "service.war"
+    And container log should contain Deployed "app-profile-jsp.war"
+    And container log should contain Deployed "app-jsp.war"
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value demo on XPath //*[local-name()='realm']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-cors']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='bearer-only']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-basic-auth'] 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value http://localhost:8080/auth on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='auth-server-url']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value service.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@entityID
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value EXTERNAL on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@sslPolicy
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /tombrady on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@logoutPage       
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='Keys']/*[local-name()='Key']/@signing 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value idp on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='IDP']/@entityID 
+
+   Scenario: deploys the keycloak examples, then checks if it's deployed.
+     Given XML namespaces
+       | prefix | url                          |
+       | ns     | urn:jboss:domain:keycloak:1.1 |
+     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts using 7.0.x-ose
+       | variable               | value                                            |
+       | ARTIFACT_DIR           | app-jee-jsp/target,app-profile-jee-jsp/target |
+       | SSO_REALM         | demo    |
+       | SSO_PUBLIC_KEY    | MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiLezsNQtZSaJvNZXTmjhlpIJnnwgGL5R1vkPLdt7odMgDzLHQ1h4DlfJPuPI4aI8uo8VkSGYQXWaOGUh3YJXtdO1vcym1SuP8ep6YnDy9vbUibA/o8RW6Wnj3Y4tqShIfuWf3MEsiH+KizoIJm6Av7DTGZSGFQnZWxBEZ2WUyFt297aLWuVM0k9vHMWSraXQo78XuU3pxrYzkI+A4QpeShg8xE7mNrs8g3uTmc53KR45+wW1icclzdix/JcT6YaSgLEVrIR9WkkYfEGj3vSrOzYA46pQe6WQoenLKtIDFmFDPjhcPoi989px9f+1HCIYP0txBS/hnJZaPdn5/lEUKQIDAQAB  |
+       | SSO_URL           | http://localhost:8080/auth    |
+    Then container log should contain JBAS015859: Deployed "app-profile-jsp.war"
+    Then container log should contain JBAS015859: Deployed "app-jsp.war"
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value demo on XPath //ns:realm/@name
+
+   Scenario: deploys the keycloak examples using secure-deployments then checks if it's deployed.
+     Given XML namespaces
+       | prefix | url                          |
+       | ns     | urn:jboss:domain:keycloak:1.1 |
+     Given s2i build http://github.com/bdecoste/keycloak-examples using securedeployments
+       | variable                   | value                                            |
+       | ARTIFACT_DIR               | app-profile-jee-saml/target,app-profile-jee/target |
+    Then container log should contain JBAS015859: Deployed "app-profile-jee.war"
+    Then container log should contain JBAS015859: Deployed "app-profile-jee-saml.war"

--- a/tests/features/6/variable_expansion.feature
+++ b/tests/features/6/variable_expansion.feature
@@ -127,17 +127,8 @@ Feature: Check correct variable expansion used
     And XML namespaces
       | prefix | url                           |
       | ns     | urn:jboss:domain:security:1.2 |
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='usersProperties' and @value='${jboss.server.config.dir}/users.properties']
-
-  Scenario: Set SECDOMAIN_USERS_PROPERTIES to null
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
-      | variable                   | value                        |
-      | EAP_SECDOMAIN_NAME         | eap-secdomain-name           |
-      | SECDOMAIN_USERS_PROPERTIES |                              |
-    And XML namespaces
-      | prefix | url                           |
-      | ns     | urn:jboss:domain:security:1.2 |
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='usersProperties' and @value='${jboss.server.config.dir}/users.properties']
+    Then container log should contain JBAS015874
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='eap-secdomain-name']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='usersProperties' and @value='${jboss.server.config.dir}/users.properties']
 
   Scenario: Set EAP_SECDOMAIN_ROLES_PROPERTIES to null
     Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
@@ -147,17 +138,8 @@ Feature: Check correct variable expansion used
     And XML namespaces
       | prefix | url                           |
       | ns     | urn:jboss:domain:security:1.2 |
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='rolesProperties' and @value='${jboss.server.config.dir}/roles.properties']
-
-  Scenario: Set SECDOMAIN_ROLES_PROPERTIES to null
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
-      | variable                   | value                        |
-      | EAP_SECDOMAIN_NAME         | eap-secdomain-name           |
-      | SECDOMAIN_ROLES_PROPERTIES |                              |
-    And XML namespaces
-      | prefix | url                           |
-      | ns     | urn:jboss:domain:security:1.2 |
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='rolesProperties' and @value='${jboss.server.config.dir}/roles.properties']
+    Then container log should contain JBAS015874
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='eap-secdomain-name']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties' and @value='${jboss.server.config.dir}/roles.properties']
 
   Scenario: Set SECDOMAIN_NAME to null
     Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
@@ -167,7 +149,8 @@ Feature: Check correct variable expansion used
     And XML namespaces
       | prefix | url                           |
       | ns     | urn:jboss:domain:security:1.2 |
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']
+    Then container log should contain JBAS015874
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='eap-secdomain-name']
 
   Scenario: Set SECDOMAIN_PASSWORD_STACKING to null
     Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
@@ -178,5 +161,5 @@ Feature: Check correct variable expansion used
     And XML namespaces
       | prefix | url                           |
       | ns     | urn:jboss:domain:security:1.2 |
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='password-stacking']
-
+    Then container log should contain JBAS015874
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='password-stacking']

--- a/tests/features/6/variable_expansion.feature
+++ b/tests/features/6/variable_expansion.feature
@@ -1,0 +1,182 @@
+@jboss-eap-6
+Feature: Check correct variable expansion used
+  Scenario: Set EAP_ADMIN_USERNAME to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_ADMIN_PASSWORD | p@ssw0rd                         |
+      | EAP_ADMIN_USERNAME |                                  |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set ADMIN_USERNAME to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_ADMIN_PASSWORD | p@ssw0rd                         |
+      | ADMIN_USERNAME     |                                  |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set ADMIN_PASSWORD to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_ADMIN_PASSWORD | p@ssw0rd                         |
+      | ADMIN_PASSWORD     |                                  |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set ADMIN_PASSWORD but not ADMIN_USERNAME
+    When container is started with env
+      | variable           | value                            |
+      | ADMIN_PASSWORD     | GoP@ts6!                         |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set NODE_NAME to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_NODE_NAME      | eap-test-node-name               |
+      | NODE_NAME          |                                  |
+    Then container log should contain jboss.node.name = eap-test-node-name
+
+  Scenario: Test setting DATA_DIR to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable    | value         |
+       | APP_DATADIR | configuration |
+       | DATA_DIR    |               |
+    Then s2i build log should contain Copying app data from configuration to /opt/eap/standalone/data
+    And run ls /opt/eap/standalone/data/standalone-openshift.xml in container and check its output for /opt/eap/standalone/data/standalone-openshift.xml
+
+  # https://issues.jboss.org/browse/CLOUD-1168
+  Scenario: Test DATA_DIR with DATA_DIR and APP_DATADIR set, DATA_DIR is not existing
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable    | value                         |
+       | APP_DATADIR | modules/org/postgresql94/main |
+       | DATA_DIR    | /tmp/test                     |
+    Then s2i build log should contain Copying app data from modules/org/postgresql94/main to /tmp/test...
+     And run ls /tmp/test/module.xml in container and check its output for /tmp/test/module.xml
+
+  # https://issues.jboss.org/browse/CLOUD-1168
+  Scenario: Test DATA_DIR with DATA_DIR and APP_DATADIR set, DATA_DIR is existing and not owned by the user
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable    | value                         |
+       | APP_DATADIR | modules/org/postgresql94/main |
+       | DATA_DIR    | /tmp                          |
+    Then s2i build log should contain Copying app data from modules/org/postgresql94/main to /tmp...
+     And run ls /tmp/module.xml in container and check its output for /tmp/module.xml
+
+  # https://issues.jboss.org/browse/CLOUD-483
+  Scenario: Test setting ARTIFACT_DIR to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable     | value       |
+       | ARTIFACT_DIR |             |
+    Then container log should contain Deployed "jboss-helloworld.war"
+
+  Scenario: Set HTTPS_NAME to null
+    Given XML namespaces
+      | prefix | url                      |
+      | ns     | urn:jboss:domain:web:2.2 |
+    When container is started with env
+      | variable               | value                        |
+      | EAP_HTTPS_NAME         | eap-test-https-name          |
+      | EAP_HTTPS_PASSWORD     | eap-test-https-password      |
+      | EAP_HTTPS_KEYSTORE_DIR | eap-test-https-keystore-dir  |
+      | EAP_HTTPS_KEYSTORE     | eap-test-https-keystore      |
+      | HTTPS_NAME             |                              |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:connector[@name='https']/ns:ssl[@name='eap-test-https-name']
+
+  Scenario: Set HTTPS_PASSWORD to null
+    Given XML namespaces
+      | prefix | url                      |
+      | ns     | urn:jboss:domain:web:2.2 |
+    When container is started with env
+      | variable               | value                        |
+      | EAP_HTTPS_NAME         | eap-test-https-name          |
+      | EAP_HTTPS_PASSWORD     | eap-test-https-password      |
+      | EAP_HTTPS_KEYSTORE_DIR | eap-test-https-keystore-dir  |
+      | EAP_HTTPS_KEYSTORE     | eap-test-https-keystore      |
+      | HTTPS_PASSWORD         |                              |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:connector[@name='https']/ns:ssl[@password='eap-test-https-password']
+
+  Scenario: Set HTTPS_KEYSTORE_DIR to null
+    Given XML namespaces
+      | prefix | url                      |
+      | ns     | urn:jboss:domain:web:2.2 |
+    When container is started with env
+      | variable               | value                        |
+      | EAP_HTTPS_NAME         | eap-test-https-name          |
+      | EAP_HTTPS_PASSWORD     | eap-test-https-password      |
+      | EAP_HTTPS_KEYSTORE_DIR | eap-test-https-keystore-dir  |
+      | EAP_HTTPS_KEYSTORE     | eap-test-https-keystore      |
+      | HTTPS_KEYSTORE_DIR     |                              |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:connector[@name='https']/ns:ssl[@certificate-key-file='eap-test-https-keystore-dir/eap-test-https-keystore']
+
+  Scenario: Set HTTPS_KEYSTORE to null
+    Given XML namespaces
+      | prefix | url                      |
+      | ns     | urn:jboss:domain:web:2.2 |
+    When container is started with env
+      | variable               | value                        |
+      | EAP_HTTPS_NAME         | eap-test-https-name          |
+      | EAP_HTTPS_PASSWORD     | eap-test-https-password      |
+      | EAP_HTTPS_KEYSTORE_DIR | eap-test-https-keystore-dir  |
+      | EAP_HTTPS_KEYSTORE     | eap-test-https-keystore      |
+      | HTTPS_KEYSTORE         |                              |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:connector[@name='https']/ns:ssl[@certificate-key-file='eap-test-https-keystore-dir/eap-test-https-keystore']
+
+  Scenario: Set EAP_SECDOMAIN_USERS_PROPERTIES to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+      | variable                       | value                        |
+      | EAP_SECDOMAIN_NAME             | eap-secdomain-name           |
+      | EAP_SECDOMAIN_USERS_PROPERTIES |                              |
+    And XML namespaces
+      | prefix | url                           |
+      | ns     | urn:jboss:domain:security:1.2 |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='usersProperties' and @value='${jboss.server.config.dir}/users.properties']
+
+  Scenario: Set SECDOMAIN_USERS_PROPERTIES to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+      | variable                   | value                        |
+      | EAP_SECDOMAIN_NAME         | eap-secdomain-name           |
+      | SECDOMAIN_USERS_PROPERTIES |                              |
+    And XML namespaces
+      | prefix | url                           |
+      | ns     | urn:jboss:domain:security:1.2 |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='usersProperties' and @value='${jboss.server.config.dir}/users.properties']
+
+  Scenario: Set EAP_SECDOMAIN_ROLES_PROPERTIES to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+      | variable                       | value                        |
+      | EAP_SECDOMAIN_NAME             | eap-secdomain-name           |
+      | EAP_SECDOMAIN_ROLES_PROPERTIES |                              |
+    And XML namespaces
+      | prefix | url                           |
+      | ns     | urn:jboss:domain:security:1.2 |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='rolesProperties' and @value='${jboss.server.config.dir}/roles.properties']
+
+  Scenario: Set SECDOMAIN_ROLES_PROPERTIES to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+      | variable                   | value                        |
+      | EAP_SECDOMAIN_NAME         | eap-secdomain-name           |
+      | SECDOMAIN_ROLES_PROPERTIES |                              |
+    And XML namespaces
+      | prefix | url                           |
+      | ns     | urn:jboss:domain:security:1.2 |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='rolesProperties' and @value='${jboss.server.config.dir}/roles.properties']
+
+  Scenario: Set SECDOMAIN_NAME to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+      | variable               | value                        |
+      | EAP_SECDOMAIN_NAME     | eap-secdomain-name           |
+      | SECDOMAIN_NAME         |                              |
+    And XML namespaces
+      | prefix | url                           |
+      | ns     | urn:jboss:domain:security:1.2 |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']
+
+  Scenario: Set SECDOMAIN_PASSWORD_STACKING to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+      | variable                        | value                           |
+      | EAP_SECDOMAIN_NAME              | eap-secdomain-name              |
+      | EAP_SECDOMAIN_PASSWORD_STACKING | eap-secdomain-password-stacking |
+      | SECDOMAIN_PASSWORD_STACKING     |                                 |
+    And XML namespaces
+      | prefix | url                           |
+      | ns     | urn:jboss:domain:security:1.2 |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //ns:security-domain[@name='eap-secdomain-name']/ns:authentication/ns:login-module/ns:module-option[@name='password-stacking']
+

--- a/tests/features/7/7.1/basic.feature
+++ b/tests/features/7/7.1/basic.feature
@@ -1,0 +1,14 @@
+@jboss-eap-7/eap71-openshift
+Feature: Common EAP CD tests
+
+  # https://issues.jboss.org/browse/CLOUD-180
+  Scenario: Check if image version and release is printed on boot
+    When container is ready
+    Then container log should contain Running jboss-eap-7/eap71-openshift image, version
+
+  Scenario: Check that the labels are correctly set
+    Given image is built
+    Then the image should contain label com.redhat.component with value jboss-eap-7-eap71-openshift-container
+     And the image should contain label name with value jboss-eap-7/eap71-openshift
+     And the image should contain label io.openshift.expose-services with value 8080:http
+     And the image should contain label io.openshift.tags with value builder,javaee,eap,eap7

--- a/tests/features/7/7.1/jgroups.feature
+++ b/tests/features/7/7.1/jgroups.feature
@@ -1,0 +1,21 @@
+@jboss-eap-7/eap71-openshift
+Feature: Openshift EAP jgroups
+
+  Scenario: jgroups-encrypt
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | eap_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WFLYSRV0039:
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='SYM_ENCRYPT']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /etc/jgroups-encrypt-secret-volume/keystore.jks on XPath //*[local-name()='protocol'][@type='SYM_ENCRYPT']/*[local-name()='property'][@name='keystore_name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss on XPath //*[local-name()='protocol'][@type='SYM_ENCRYPT']/*[local-name()='property'][@name='alias']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mykeystorepass on XPath //*[local-name()='protocol'][@type='SYM_ENCRYPT']/*[local-name()='property'][@name='store_password']
+     # https://issues.jboss.org/browse/CLOUD-1189
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK2 for udp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()='stack'][@name='udp']/*[local-name()='protocol'][@type='SYM_ENCRYPT']/following-sibling::*[1]/@type
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK2 for tcp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()='stack'][@name='tcp']/*[local-name()='protocol'][@type='SYM_ENCRYPT']/following-sibling::*[1]/@type

--- a/tests/features/7/7.1/logging.feature
+++ b/tests/features/7/7.1/logging.feature
@@ -1,0 +1,16 @@
+@jboss-eap-7/eap71-openshift
+Feature: Check logging configuration
+
+  Scenario: Check that EAP CD logs are json formatted
+    When container is started with env
+       | variable                    | value             |
+       | ENABLE_JSON_LOGGING         | true              |
+    Then container log should contain "message":"WFLYSRV0025: JBoss EAP 7.1.4.GA
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value OPENSHIFT on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name
+
+  Scenario: Check that EAP7 logs are normally formatted
+    When container is started with env
+       | variable                    | value              |
+       | ENABLE_JSON_LOGGING         | false              |
+    Then container log should contain WFLYSRV0025: JBoss EAP 7.1.4.GA
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value COLOR-PATTERN on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name

--- a/tests/features/7/7.1/security_domains.feature
+++ b/tests/features/7/7.1/security_domains.feature
@@ -1,0 +1,16 @@
+@jboss-eap-7/eap71-openshift
+Feature: EAP Openshift security domains
+  Scenario: check Elytron configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable           | value       |
+       | SECDOMAIN_NAME     | application-security     |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='elytron-integration']/*[local-name()='security-realms']/*[local-name()='elytron-realm']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='elytron-integration']/*[local-name()='security-realms']/*[local-name()='elytron-realm']/@legacy-jaas-config
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:ejb3:5.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:ejb3:5.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@security-domain
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:undertow:4.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security-http on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:undertow:4.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@http-authentication-factory
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value BASIC on XPath //*[local-name()='http-authentication-factory'][@name='application-security-http'][@security-domain='application-security']/*[local-name()='mechanism-configuration']/*[local-name()='mechanism'][1]/@mechanism-name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value FORM on XPath //*[local-name()='http-authentication-factory'][@name='application-security-http'][@security-domain='application-security']/*[local-name()='mechanism-configuration']/*[local-name()='mechanism'][2]/@mechanism-name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='security-domain'][@name='application-security'][@default-realm='application-security']/*[local-name()='realm']/@name

--- a/tests/features/7/7.2/basic.feature
+++ b/tests/features/7/7.2/basic.feature
@@ -1,0 +1,14 @@
+@jboss-eap-7/eap72-openshift
+Feature: Common EAP CD tests
+
+  # https://issues.jboss.org/browse/CLOUD-180
+  Scenario: Check if image version and release is printed on boot
+    When container is ready
+    Then container log should contain Running jboss-eap-7/eap72-openshift image, version
+
+  Scenario: Check that the labels are correctly set
+    Given image is built
+    Then the image should contain label com.redhat.component with value jboss-eap-7-eap-72-openshift-container
+     And the image should contain label name with value jboss-eap-7/eap72-openshift
+     And the image should contain label io.openshift.expose-services with value 8080:http
+     And the image should contain label io.openshift.tags with value builder,javaee,eap,eap7

--- a/tests/features/7/7.2/jgroups.feature
+++ b/tests/features/7/7.2/jgroups.feature
@@ -1,0 +1,31 @@
+@jboss-eap-7/eap72-openshift
+Feature: Openshift EAP jgroups
+  Scenario: jgroups-encrypt
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | eap_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WFLYSRV0039:
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='encrypt-protocol'][@type='SYM_ENCRYPT']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value keystore.jks on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/@key-store
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/@key-alias
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mykeystorepass on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/*[local-name()="key-credential-reference"]/@clear-text
+     # https://issues.jboss.org/browse/CLOUD-1192
+     # https://issues.jboss.org/browse/CLOUD-1196
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for udp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for tcp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+
+  Scenario: Check jgroups encryption with missing keystore dir creates the location relative to the server dir
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss.server.config.dir on XPath //*[local-name()="key-store"][@name="keystore.jks"]/*[local-name()="file"]/@relative-to

--- a/tests/features/7/7.2/logging.feature
+++ b/tests/features/7/7.2/logging.feature
@@ -1,0 +1,16 @@
+@jboss-eap-7/eap72-openshift
+Feature: Check logging configuration
+
+  Scenario: Check that EAP CD logs are json formatted
+    When container is started with env
+       | variable                    | value             |
+       | ENABLE_JSON_LOGGING         | true              |
+    Then container log should contain "message":"WFLYSRV0025: JBoss EAP 7.2.0.GA
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value OPENSHIFT on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name
+
+  Scenario: Check that EAP7 logs are normally formatted
+    When container is started with env
+       | variable                    | value              |
+       | ENABLE_JSON_LOGGING         | false              |
+    Then container log should contain WFLYSRV0025: JBoss EAP 7.2.0.GA
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value COLOR-PATTERN on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name

--- a/tests/features/7/7.2/security_domains.feature
+++ b/tests/features/7/7.2/security_domains.feature
@@ -1,0 +1,16 @@
+@jboss-eap-7/eap72-openshift
+Feature: EAP Openshift security domains
+  Scenario: check Elytron configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable           | value       |
+       | SECDOMAIN_NAME     | application-security     |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='elytron-integration']/*[local-name()='security-realms']/*[local-name()='elytron-realm']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='elytron-integration']/*[local-name()='security-realms']/*[local-name()='elytron-realm']/@legacy-jaas-config
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:ejb3:5.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:ejb3:5.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@security-domain
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:undertow:7.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security-http on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:undertow:7.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@http-authentication-factory
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value BASIC on XPath //*[local-name()='http-authentication-factory'][@name='application-security-http'][@security-domain='application-security']/*[local-name()='mechanism-configuration']/*[local-name()='mechanism'][1]/@mechanism-name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value FORM on XPath //*[local-name()='http-authentication-factory'][@name='application-security-http'][@security-domain='application-security']/*[local-name()='mechanism-configuration']/*[local-name()='mechanism'][2]/@mechanism-name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='security-domain'][@name='application-security'][@default-realm='application-security']/*[local-name()='realm']/@name

--- a/tests/features/7/CD/basic.feature
+++ b/tests/features/7/CD/basic.feature
@@ -1,0 +1,14 @@
+@jboss-eap-7/eap-cd-openshift
+Feature: Common EAP CD tests
+
+  # https://issues.jboss.org/browse/CLOUD-180
+  Scenario: Check if image version and release is printed on boot
+    When container is ready
+    Then container log should contain Running jboss-eap-7/eap-cd-openshift image, version
+
+  Scenario: Check that the labels are correctly set
+    Given image is built
+    Then the image should contain label com.redhat.component with value jboss-eap-7-eap-cd-openshift-container
+     And the image should contain label name with value jboss-eap-7/eap-cd-openshift
+     And the image should contain label io.openshift.expose-services with value 8080:http
+     And the image should contain label io.openshift.tags with value builder,javaee,eap,eap7

--- a/tests/features/7/CD/jgroups.feature
+++ b/tests/features/7/CD/jgroups.feature
@@ -1,0 +1,31 @@
+@jboss-eap-7/eap-cd-openshift
+Feature: Openshift EAP jgroups
+  Scenario: jgroups-encrypt
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | eap_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WFLYSRV0039:
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='encrypt-protocol'][@type='SYM_ENCRYPT']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value keystore.jks on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/@key-store
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/@key-alias
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mykeystorepass on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/*[local-name()="key-credential-reference"]/@clear-text
+     # https://issues.jboss.org/browse/CLOUD-1192
+     # https://issues.jboss.org/browse/CLOUD-1196
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for udp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for tcp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+
+  Scenario: Check jgroups encryption with missing keystore dir creates the location relative to the server dir
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss.server.config.dir on XPath //*[local-name()="key-store"][@name="keystore.jks"]/*[local-name()="file"]/@relative-to

--- a/tests/features/7/CD/logging.feature
+++ b/tests/features/7/CD/logging.feature
@@ -1,0 +1,16 @@
+@jboss-eap-7/eap-cd-openshift
+Feature: Check logging configuration
+
+  Scenario: Check that EAP CD logs are json formatted
+    When container is started with env
+       | variable                    | value             |
+       | ENABLE_JSON_LOGGING         | true              |
+    Then container log should contain "message":"WFLYSRV0025: JBoss EAP CD 7.2.0.CD
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value OPENSHIFT on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name
+
+  Scenario: Check that EAP7 logs are normally formatted
+    When container is started with env
+       | variable                    | value              |
+       | ENABLE_JSON_LOGGING         | false              |
+    Then container log should contain WFLYSRV0025: JBoss EAP CD 7.2.0.CD
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value COLOR-PATTERN on XPath //*[local-name()='console-handler']/*[local-name()='formatter']/*[local-name()='named-formatter']/@name

--- a/tests/features/7/CD/security_domains.feature
+++ b/tests/features/7/CD/security_domains.feature
@@ -1,0 +1,16 @@
+@jboss-eap-7/eap-cd-openshift
+Feature: EAP Openshift security domains
+  Scenario: check Elytron configuration
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable           | value       |
+       | SECDOMAIN_NAME     | application-security     |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='elytron-integration']/*[local-name()='security-realms']/*[local-name()='elytron-realm']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='elytron-integration']/*[local-name()='security-realms']/*[local-name()='elytron-realm']/@legacy-jaas-config
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:ejb3:5.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:ejb3:5.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@security-domain
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:undertow:7.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security-http on XPath //*[local-name()='subsystem'][namespace-uri()='urn:jboss:domain:undertow:7.0']/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@http-authentication-factory
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value BASIC on XPath //*[local-name()='http-authentication-factory'][@name='application-security-http'][@security-domain='application-security']/*[local-name()='mechanism-configuration']/*[local-name()='mechanism'][1]/@mechanism-name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value FORM on XPath //*[local-name()='http-authentication-factory'][@name='application-security-http'][@security-domain='application-security']/*[local-name()='mechanism-configuration']/*[local-name()='mechanism'][2]/@mechanism-name
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='security-domain'][@name='application-security'][@default-realm='application-security']/*[local-name()='realm']/@name

--- a/tests/features/7/basic.feature
+++ b/tests/features/7/basic.feature
@@ -1,0 +1,218 @@
+@jboss-eap-7
+Feature: Common EAP tests
+
+  Scenario: Check for add-user failures
+    When container is ready
+    Then container log should contain Running jboss-eap-7
+     And available container log should not contain AddUserFailedException
+
+  Scenario: Cloud-1784, make the Access Log Valve configurable
+    When container is started with env
+      | variable          | value                 |
+      | ENABLE_ACCESS_LOG | true                  |
+    Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <access-log use-server-log="true" pattern="%h %l %u %t %{i,X-Forwarded-Host} &quot;%r&quot; %s %b"/>
+
+  Scenario: Management interface is secured and JAVA_OPTS is modified
+    When container is started with env
+       | variable                | value             |
+       | ADMIN_USERNAME          | admin2            |
+       | ADMIN_PASSWORD          | lollerskates11$   |
+       | JAVA_OPTS_APPEND        | -Dfoo=bar         |
+    Then container log should contain WFLYSRV0025
+     And run /opt/eap/bin/jboss-cli.sh -c --error-on-interact --no-local-auth --user=admin2 --password=lollerskates11$ :whoami in container and immediately check its output contains admin2
+     # We expect this command to fail, so make sure the return code is zero, we're interested only in output here
+     And run sh -c '/opt/eap/bin/jboss-cli.sh -c --error-on-interact --no-local-auth deployment-info || true' in container and immediately check its output contains Unable to authenticate
+     And container log should contain -Dfoo=bar
+
+  # https://issues.jboss.org/browse/CLOUD-587 (security realm for management API)
+  # CLOUD-834 (probe rework) uses http interface, which cannot use "local" user,
+  #     even when the request originates from localhost, which is how jboss-cli
+  #     works.  Note too that http interface is only bound to localhost.
+  #     setting to @ignore for now.
+  # For EAP 7.0 and derived images
+  Scenario: Management interface is secured (no warning message)
+    When container is ready
+    # The below should complete faster than 'should not contain' alone
+    # this is the key for the "JBoss EAP 7.a.b.GA (WildFly Core x.y.z.Final-redhat-1) started" message
+    Then container log should contain WFLYSRV0025
+     And available container log should not contain No security realm defined for http management service; all access will be unrestricted.
+
+  Scenario: Java 1.8 is installed and set as default one
+    When container is ready
+    Then run java -version in container and check its output for openjdk version "1.8.0
+    Then run javac -version in container and check its output for javac 1.8.0
+
+  Scenario: readinessProbe runs successfully
+    When container is ready
+    Then run /opt/eap/bin/readinessProbe.sh in container once
+    Then run /opt/eap/bin/livenessProbe.sh in container once
+
+  # https://issues.jboss.org/browse/CLOUD-204
+  Scenario: Check if kube ping protocol is used by default
+    When container is ready
+    # 2 matches, one for TCP, one for UDP
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='openshift.KUBE_PING']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='protocol'][@type='openshift.DNS_PING']
+
+  # https://issues.jboss.org/browse/CLOUD-1958
+  Scenario: Check if kube ping protocol is used when specified
+    When container is started with env
+      | variable                             | value           |
+      | JGROUPS_PING_PROTOCOL                | openshift.KUBE_PING     |
+    # 2 matches, one for TCP, one for UDP
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='openshift.KUBE_PING']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='protocol'][@type='openshift.DNS_PING']
+
+  # https://issues.jboss.org/browse/CLOUD-1958
+  Scenario: Check if dns ping protocol is used when specified
+    When container is started with env
+      | variable                             | value           |
+      | JGROUPS_PING_PROTOCOL                | openshift.DNS_PING     |
+    # 2 matches, one for TCP, one for UDP
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()="protocol"][@type="openshift.DNS_PING"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()="protocol"][@type="openshift.KUBE_PING"]
+
+  Scenario: Check if jolokia is configured correctly
+    When container is ready
+    Then container log should contain -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
+
+  # https://issues.jboss.org/browse/CLOUD-295
+  # https://issues.jboss.org/browse/CLOUD-336
+  Scenario: Check if jgroups is secure
+    When container is started with env
+       | variable                 | value    |
+       | JGROUPS_CLUSTER_PASSWORD | asdfasdf |
+       | JGROUPS_ENCRYPT_SECRET                       | eap_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                     |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='auth-protocol'][@type='AUTH']
+
+  Scenario: Check jgroups AUTH protocol is disabled when using SYM_ENCRYPT and JGROUPS_CLUSTER_PASSWORD undefined
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='protocol'][@type='AUTH']
+     And container log should contain WARN No password defined for JGroups cluster. AUTH protocol will be disabled. Please define JGROUPS_CLUSTER_PASSWORD.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with encrypt secret undefined
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+    Then container log should contain WARN Detected missing JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with missing name
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with missing password
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration when using SYM_ENCRYPT with missing keystore file
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | SYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption requires AUTH protocol to be set when using ASYM_ENCRYPT protocol
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WARN No password defined for JGroups cluster. AUTH protocol will be disabled. Please define JGROUPS_CLUSTER_PASSWORD.
+
+  @ignore
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_SECRET defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret              |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  @ignore
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_NAME defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                   |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  @ignore
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_PASSWORD defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                          |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  @ignore
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_KEYSTORE_DIR defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume      |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  @ignore
+  Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_KEYSTORE file defined
+    When container is started with env
+       | variable                                     | value                                   |
+       | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                            |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WARN The specified JGroups SYM_ENCRYPT JCEKS keystore definition will be ignored when using ASYM_ENCRYPT.
+
+  Scenario: No duplicate module jars
+    When container is ready
+    Then files at /opt/eap/modules/system/layers/openshift/org/jgroups/main should have count of 2
+
+  Scenario: jboss.modules.system.pkgs is set to defaults when JBOSS_MODULES_SYSTEM_PKGS_APPEND env var is not set
+    When container is ready
+    Then container log should contain VM Arguments:
+     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider
+
+  Scenario: jboss.modules.system.pkgs will contain default value and the value of JBOSS_MODULES_SYSTEM_PKGS_APPEND env var, when it is set
+    When container is started with env
+      | variable                             | value           |
+      | JBOSS_MODULES_SYSTEM_PKGS_APPEND     | org.foo.bar     |
+    Then container log should contain VM Arguments:
+     And available container log should contain -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider,org.foo.bar
+
+  Scenario: check ownership when started as alternative UID
+    When container is started as uid 26458
+    Then container log should contain Running
+     And run id -u in container and check its output contains 26458
+     And all files under /opt/eap are writeable by current user
+     And all files under /deployments are writeable by current user
+
+   Scenario: HTTP proxy as java properties (CLOUD-865) and disable web console (CLOUD-1040)
+    When container is started with env
+      | variable   | value                 |
+      | HTTP_PROXY | http://localhost:1337 |
+    Then container log should contain Admin console is not enabled
+     And container log should contain VM Arguments:
+     And available container log should contain http.proxyHost = localhost
+     And available container log should contain http.proxyPort = 1337

--- a/tests/features/7/datasource.feature
+++ b/tests/features/7/datasource.feature
@@ -1,0 +1,702 @@
+@jboss-eap-7
+Feature: EAP Openshift datasources
+
+  Scenario: check mysql datasource
+    When container is started with env
+       | variable                  | value            |
+       | DB_SERVICE_PREFIX_MAPPING | test-mysql=TEST |
+       | TEST_DATABASE             | kitchensink      |
+       | TEST_USERNAME             | marek            |
+       | TEST_PASSWORD             | hardtoguess      |
+       | TEST_MYSQL_SERVICE_HOST   | 10.1.1.1         |
+       | TEST_MYSQL_SERVICE_PORT   | 3306             |
+       | TIMER_SERVICE_DATA_STORE  | test-mysql       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_ds on XPath //*[local-name()='timer-service']/@default-data-store
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_ds on XPath //*[local-name()='database-data-store']/@name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='database-data-store']/@database
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_part on XPath //*[local-name()='database-data-store']/@partition
+
+  Scenario: check mysql datasource with advanced settings
+    When container is started with env
+       | variable                  | value                       |
+       | DB_SERVICE_PREFIX_MAPPING | test-mysql=TEST             |
+       | TEST_DATABASE             | kitchensink                 |
+       | TEST_USERNAME             | marek                       |
+       | TEST_PASSWORD             | hardtoguess                 |
+       | TEST_MIN_POOL_SIZE        | 1                           |
+       | TEST_MAX_POOL_SIZE        | 10                          |
+       | TEST_TX_ISOLATION         | TRANSACTION_REPEATABLE_READ |
+       | TEST_MYSQL_SERVICE_HOST   | 10.1.1.1                    |
+       | TEST_MYSQL_SERVICE_PORT   | 3306                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value TRANSACTION_REPEATABLE_READ on XPath //*[local-name()='xa-datasource']/*[local-name()='transaction-isolation']
+
+  Scenario: check mysql datasource with partial advanced settings
+    When container is started with env
+       | variable                  | value                       |
+       | DB_SERVICE_PREFIX_MAPPING | test-mysql=TEST             |
+       | TEST_DATABASE             | kitchensink                 |
+       | TEST_USERNAME             | marek                       |
+       | TEST_PASSWORD             | hardtoguess                 |
+       | TEST_MAX_POOL_SIZE        | 10                          |
+       | TEST_MYSQL_SERVICE_HOST   | 10.1.1.1                    |
+       | TEST_MYSQL_SERVICE_PORT   | 3306                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  # https://issues.jboss.org/browse/CLOUD-508
+  Scenario: check default for timer service datastore
+    When container is ready
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value default-file-store on XPath //*[local-name()='file-data-store']/@name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='timer-service']/*[local-name()='data-stores']
+
+  Scenario: check postgresql datasource
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_DATABASE                 | kitchensink                |
+       | TEST_USERNAME                 | marek                      |
+       | TEST_PASSWORD                 | hardtoguess                |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+       | TIMER_SERVICE_DATA_STORE      | test-postgresql            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_ds on XPath //*[local-name()='timer-service']/@default-data-store
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_ds on XPath //*[local-name()='database-data-store']/@name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value postgresql on XPath //*[local-name()='database-data-store']/@database
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_part on XPath //*[local-name()='database-data-store']/@partition
+
+  Scenario: check postgresql datasource with advanced settings
+    When container is started with env
+       | variable                      | value                       |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST        |
+       | TEST_DATABASE                 | kitchensink                 |
+       | TEST_USERNAME                 | marek                       |
+       | TEST_PASSWORD                 | hardtoguess                 |
+       | TEST_MIN_POOL_SIZE            | 1                           |
+       | TEST_MAX_POOL_SIZE            | 10                          |
+       | TEST_TX_ISOLATION             | TRANSACTION_REPEATABLE_READ |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                    |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value TRANSACTION_REPEATABLE_READ on XPath //*[local-name()='xa-datasource']/*[local-name()='transaction-isolation']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test database type is extracted properly even when name contains a dash (e.g. "eap-app")
+    When container is started with env
+      | variable                         | value                         |
+      | DB_SERVICE_PREFIX_MAPPING        | eap-app-postgresql=TEST       |
+      | TEST_DATABASE                    | kitchensink                   |
+      | TEST_USERNAME                    | marek                         |
+      | TEST_PASSWORD                    | hardtoguess                   |
+      | EAP_APP_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                      |
+      | EAP_APP_POSTGRESQL_SERVICE_PORT  | 5432                          |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/eap_app_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value eap_app_postgresql-TEST on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: check mysql and postgresql datasource
+    When container is started with env
+       | variable                      | value                                                  |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST_POSTGRESQL,test-mysql=TEST_MYSQL  |
+       | TEST_MYSQL_DATABASE           | kitchensink-m                                          |
+       | TEST_MYSQL_USERNAME           | marek-m                                                |
+       | TEST_MYSQL_PASSWORD           | hardtoguess-m                                          |
+       | TEST_MYSQL_SERVICE_HOST       | 10.1.1.1                                               |
+       | TEST_MYSQL_SERVICE_PORT       | 3306                                                   |
+       | TEST_POSTGRESQL_DATABASE      | kitchensink-p                                          |
+       | TEST_POSTGRESQL_USERNAME      | marek-p                                                |
+       | TEST_POSTGRESQL_PASSWORD      | hardtoguess-p                                          |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.2                                               |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresql-TEST_POSTGRESQL on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink-p on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek-p on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess-p on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_mysql-TEST_MYSQL on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.2 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink-m on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value marek-m on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hardtoguess-m on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: check that exampleDS is generated by default (CLOUD-7)
+    When container is started with env
+       | variable                      | value                                                  |
+       | TIMER_SERVICE_DATA_STORE      | ExampleDS            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ExampleDS on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ExampleDS on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ExampleDS_ds on XPath //*[local-name()='database-data-store']/@name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/ExampleDS on XPath //*[local-name()='database-data-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hsql on XPath //*[local-name()='database-data-store']/@database
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ExampleDS_part on XPath //*[local-name()='database-data-store']/@partition
+
+  Scenario: Test warning no username is provided
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_DATABASE                 | kitchensink                |
+       | TEST_PASSWORD                 | hardtoguess                |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+    Then container log should contain WARN The postgresql datasource for TEST service WILL NOT be configured.
+    And container log should contain TEST_PASSWORD: hardtoguess
+
+  Scenario: Test warning on missing database type
+    When container is started with env
+       | variable                      | value                |
+       | DB_SERVICE_PREFIX_MAPPING     | test=TEST            |
+       | TEST_DATABASE                 | kitchensink          |
+       | TEST_USERNAME                 | marek                |
+       | TEST_PASSWORD                 | hardtoguess          |
+       | TEST_SERVICE_HOST             | 10.1.1.1             |
+       | TEST_SERVICE_PORT             | 5432                 |
+    Then container log should contain The mapping does not contain the database type.
+    Then container log should contain WARN The datasource for TEST service WILL NOT be configured.
+
+  Scenario: Test warning on missing driver
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_DATABASE                  | pgdb                                   |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+    Then container log should contain WARN DRIVER not set for datasource TEST. Datasource will not be configured.
+
+  Scenario: Test postgresql xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | postgresql                             |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_DATABASE                  | pgdb                                   |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+       | JDBC_STORE_JNDI_NAME           | java:/jboss/datasources/testds         |
+       | NODE_NAME                      | TestStoreNodeName                      |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pgdb on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='jdbc-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='action']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='communication']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='state']/@table-prefix
+
+  @redhat-sso-7/sso71-openshift
+  Scenario: Test postgresql xa datasource extension with TX_DATABASE_PREFIX_MAPPING
+    When container is started with env
+       | variable                       | value                                  |
+       | TX_DATABASE_PREFIX_MAPPING     | TEST_POSTGRESQL                        |
+       | TEST_POSTGRESQL_JNDI           | java:/jboss/datasources/testds         |
+       | TEST_POSTGRESQL_USERNAME       | tombrady                               |
+       | TEST_POSTGRESQL_PASSWORD       | password                               |
+       | TEST_POSTGRESQL_SERVICE_HOST   | 10.1.1.1                               |
+       | TEST_POSTGRESQL_SERVICE_PORT   | 5432                                   |
+       | TEST_POSTGRESQL_DATABASE       | pgdb                                   |
+       | NODE_NAME                      | TestStoreNodeName                      |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testdsObjectStore on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='datasource']/@jta
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresqlObjectStorePool on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='datasource']/@enabled
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/pgdb on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value postgresql on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='action']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='communication']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='state']/@table-prefix
+
+  Scenario: Test postgresql xa datasource extension with hyphenated node name
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | postgresql                             |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_DATABASE                  | pgdb                                   |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+       | JDBC_STORE_JNDI_NAME           | java:/jboss/datasources/testds         |
+       | NODE_NAME                      | Test-Store-Node-Name                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5432 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="PortNumber"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pgdb on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='jdbc-store']/@datasource-jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='action']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='communication']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='state']/@table-prefix
+
+  @redhat-sso-7/sso71-openshift
+  Scenario: Test postgresql xa datasource extension with TX_DATABASE_PREFIX_MAPPING and hyphenated node name
+    When container is started with env
+       | variable                       | value                                  |
+       | TX_DATABASE_PREFIX_MAPPING     | TEST_POSTGRESQL                        |
+       | TEST_POSTGRESQL_JNDI           | java:/jboss/datasources/testds         |
+       | TEST_POSTGRESQL_USERNAME       | tombrady                               |
+       | TEST_POSTGRESQL_PASSWORD       | password                               |
+       | TEST_POSTGRESQL_SERVICE_HOST   | 10.1.1.1                               |
+       | TEST_POSTGRESQL_SERVICE_PORT   | 5432                                   |
+       | TEST_POSTGRESQL_DATABASE       | pgdb                                   |
+       | NODE_NAME                      | Test-Store-Node-Name                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testdsObjectStore on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='datasource']/@jta
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test_postgresqlObjectStorePool on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='datasource']/@enabled
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/pgdb on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value postgresql on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='action']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='communication']/@table-prefix
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value osTestStoreNodeName on XPath //*[local-name()='jdbc-store']/*[local-name()='state']/@table-prefix
+
+  Scenario: Test postgresql non-xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | postgresql                             |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_DATABASE                  | pgdb                                   |
+       | TEST_NONXA                     | true                                   |
+       | TEST_JTA                       | false                                  |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/pgdb on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+
+  Scenario: Test postgresql xa datasource extension w/URL
+    When container is started with env
+       | variable                        | value                                  |
+       | DATASOURCES                     | TEST                                   |
+       | TEST_JNDI                       | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                     | postgresql                             |
+       | TEST_USERNAME                   | tombrady                               |
+       | TEST_PASSWORD                   | password                               |
+       | TEST_XA_CONNECTION_PROPERTY_URL | jdbc:postgresql://10.1.1.1:5432/pgdb   |
+       | TEST_NONXA                      | false                                  |
+       | TEST_JTA                        | true                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/pgdb on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+
+  Scenario: Test mysql xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | mysql                                  |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 3306                                   |
+       | TEST_DATABASE                  | kitchensink                            |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+
+  Scenario: Test mysql non-xa datasource extension
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | mysql                                  |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_SERVICE_PORT              | 3306                                   |
+       | TEST_DATABASE                  | kitchensink                            |
+       | TEST_NONXA                     | true                                   |
+       | TEST_JTA                       | false                                  |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/kitchensink on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+
+  Scenario: Test mysql xa datasource extension w/URL
+    When container is started with env
+       | variable                        | value                                  |
+       | DATASOURCES                     | TEST                                   |
+       | TEST_JNDI                       | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                     | mysql                                  |
+       | TEST_USERNAME                   | tombrady                               |
+       | TEST_PASSWORD                   | password                               |
+       | TEST_XA_CONNECTION_PROPERTY_URL | jdbc:mysql://10.1.1.1:3306/kitchensink |
+       | TEST_NONXA                      | false                                  |
+       | TEST_JTA                        | true                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property']
+
+  Scenario: Test external xa datasource extension
+    When container is started with env
+       | variable                          | value                                      |
+       | DATASOURCES                       | TEST                                       |
+       | TEST_JNDI                         | java:/jboss/datasources/testds             |
+       | TEST_DRIVER                       | oracle                                     |
+       | TEST_USERNAME                     | tombrady                                   |
+       | TEST_PASSWORD                     | password                                   |
+       | TEST_XA_CONNECTION_PROPERTY_URL   | jdbc:oracle:thin:@samplehost:1521:oracledb |
+       | TEST_NONXA                        | false                                      |
+       | TEST_JTA                          | true                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:oracle:thin:@samplehost:1521:oracledb on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="URL"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value oracle on XPath //*[local-name()='xa-datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test external non-xa datasource extension
+    When container is started with env
+       | variable                          | value                                      |
+       | DATASOURCES                       | TEST                                       |
+       | TEST_JNDI                         | java:/jboss/datasources/testds             |
+       | TEST_DRIVER                       | oracle                                     |
+       | TEST_USERNAME                     | tombrady                                   |
+       | TEST_PASSWORD                     | password                                   |
+       | TEST_SERVICE_PORT                 | 1521                                       |
+       | TEST_SERVICE_HOST                 | 10.1.1.1                                   |
+       | TEST_DATABASE                     | oracledb                                   |
+       | TEST_URL                          | jdbc:oracle:thin:@samplehost:1521:oracledb |
+       | TEST_NONXA                        | true                                       |
+       | TEST_JTA                          | false                                      |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:oracle:thin:@samplehost:1521:oracledb on XPath //*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value oracle on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test warning no xa-connection-properties for external xa db
+    When container is started with env
+       | variable                       | value                                  |
+       | DATASOURCES                    | TEST                                   |
+       | TEST_JNDI                      | java:/jboss/datasources/testds         |
+       | TEST_DRIVER                    | oracle                                 |
+       | TEST_USERNAME                  | tombrady                               |
+       | TEST_PASSWORD                  | password                               |
+       | TEST_SERVICE_HOST              | 10.1.1.1                               |
+       | TEST_DATABASE                  | testdb                                 |
+       | TEST_SERVICE_PORT              | 5432                                   |
+       | TEST_NONXA                     | false                                  |
+       | TEST_JTA                       | true                                   |
+    Then container log should contain WARN At least one TEST_XA_CONNECTION_PROPERTY_property for datasource TEST is required. Datasource will not be configured.
+
+  Scenario: Test warning no password is provided
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_DATABASE                 | kitchensink                |
+       | TEST_USERNAME                 | marek                      |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+    Then container log should contain WARN The postgresql datasource for TEST service WILL NOT be configured.
+    And container log should contain TEST_JNDI: java:jboss/datasources/test_postgresql
+    And container log should contain TEST_USERNAME: marek
+
+  Scenario: Test warning no database is provided
+    When container is started with env
+       | variable                      | value                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST       |
+       | TEST_USERNAME                 | marek                      |
+       | TEST_PASSWORD                 | hardtoguess                |
+       | TEST_POSTGRESQL_SERVICE_HOST  | 10.1.1.1                   |
+       | TEST_POSTGRESQL_SERVICE_PORT  | 5432                       |
+   Then container log should contain WARN Missing configuration for datasource TEST. TEST_POSTGRESQL_SERVICE_HOST, TEST_POSTGRESQL_SERVICE_PORT, and/or TEST_DATABASE is missing. Datasource will not be configured.
+
+  Scenario: Test warning on wrong mapping
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=MAREK,abc-mysql=DB         |
+       | MAREK_USERNAME                | marek                                      |
+       | MAREK_PASSWORD                | hardtoguess                                |
+   Then container log should contain WARN Missing configuration for datasource MAREK. TEST_POSTGRESQL_SERVICE_HOST, TEST_POSTGRESQL_SERVICE_PORT, and/or MAREK_DATABASE is missing. Datasource will not be configured.
+   And container log should contain In order to configure mysql datasource for DB service you need to provide following environment variables: DB_USERNAME and DB_PASSWORD.
+
+  Scenario: Test warning for missing postgresql xa properties
+    When container is started with env
+       | variable                      | value                      |
+       | DATASOURCES                   | TEST                       |
+       | TEST_USERNAME                 | tombrady                   |
+       | TEST_PASSWORD                 | Need6Rings!                |
+       | TEST_DRIVER                   | postgresql                 |
+    Then container log should contain WARN Missing configuration for XA datasource TEST. Either TEST_XA_CONNECTION_PROPERTY_URL or TEST_XA_CONNECTION_PROPERTY_ServerName, and TEST_XA_CONNECTION_PROPERTY_PortNumber, and TEST_XA_CONNECTION_PROPERTY_DatabaseName is required. Datasource will not be configured.
+
+  Scenario: Test warning for missing mysql xa properties
+    When container is started with env
+       | variable                      | value                      |
+       | DATASOURCES                   | TEST                       |
+       | TEST_USERNAME                 | tombrady                   |
+       | TEST_PASSWORD                 | Need6Rings!                |
+       | TEST_DRIVER                   | mysql                      |
+    Then container log should contain WARN Missing configuration for XA datasource TEST. Either TEST_XA_CONNECTION_PROPERTY_URL or TEST_XA_CONNECTION_PROPERTY_ServerName, and TEST_XA_CONNECTION_PROPERTY_Port, and TEST_XA_CONNECTION_PROPERTY_DatabaseName is required. Datasource will not be configured.
+
+   Scenario: Test multiple datasources with one incorrect
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | pg-postgresql=PG,mysql-mysql=MYSQL         |
+       | PG_USERNAME                   | pguser                                     |
+       | PG_PASSWORD                   | pgpass                                     |
+       | PG_POSTGRESQL_SERVICE_HOST    | 10.1.1.1                                   |
+       | PG_POSTGRESQL_SERVICE_PORT    | 5432                                       |
+       | MYSQL_DATABASE                | kitchensink                                |
+       | MYSQL_USERNAME                | mysqluser                                  |
+       | MYSQL_PASSWORD                | mysqlpass                                  |
+       | MYSQL_MYSQL_SERVICE_HOST      | 10.1.1.1                                   |
+       | MYSQL_MYSQL_SERVICE_PORT      | 3306                                       |
+    Then container log should contain WARN Missing configuration for datasource PG. PG_POSTGRESQL_SERVICE_HOST, PG_POSTGRESQL_SERVICE_PORT, and/or PG_DATABASE is missing. Datasource will not be configured.
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/mysql_mysql on XPath //*[local-name()='xa-datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql_mysql-MYSQL on XPath //*[local-name()='xa-datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10.1.1.1 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="ServerName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3306 on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="Port"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value kitchensink on XPath //*[local-name()='xa-datasource']/*[local-name()='xa-datasource-property'][@name="DatabaseName"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqluser on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqlpass on XPath //*[local-name()='xa-datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test tx db service mapping w/multiple datasources
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | pg-postgresql=PG,mysql-mysql=MYSQL         |
+       | TX_DATABASE_PREFIX_MAPPING    | mysql-mysql=MYSQL                          |
+       | PG_DATABASE                   | kitchensink                                |
+       | PG_USERNAME                   | pguser                                     |
+       | PG_PASSWORD                   | pgpass                                     |
+       | PG_POSTGRESQL_SERVICE_HOST    | 10.1.1.1                                   |
+       | PG_POSTGRESQL_SERVICE_PORT    | 5432                                       |
+       | MYSQL_DATABASE                | kitchensink                                |
+       | MYSQL_USERNAME                | mysqluser                                  |
+       | MYSQL_PASSWORD                | mysqlpass                                  |
+       | MYSQL_MYSQL_SERVICE_HOST      | 10.1.1.1                                   |
+       | MYSQL_MYSQL_SERVICE_PORT      | 3306                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/mysql_mysqlObjectStore on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql_mysqlObjectStorePool on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:mysql://10.1.1.1:3306/kitchensink on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqluser on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysqlpass on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test tx db service mapping w/multiple datasources and tx is first
+    When container is started with env
+       | variable                      | value                                      |
+       | DB_SERVICE_PREFIX_MAPPING     | pg-postgresql=PG,mysql-mysql=MYSQL         |
+       | TX_DATABASE_PREFIX_MAPPING    | pg-postgresql=PG                           |
+       | PG_DATABASE                   | kitchensink                                |
+       | PG_USERNAME                   | pguser                                     |
+       | PG_PASSWORD                   | pgpass                                     |
+       | PG_POSTGRESQL_SERVICE_HOST    | 10.1.1.1                                   |
+       | PG_POSTGRESQL_SERVICE_PORT    | 5432                                       |
+       | MYSQL_DATABASE                | kitchensink                                |
+       | MYSQL_USERNAME                | mysqluser                                  |
+       | MYSQL_PASSWORD                | mysqlpass                                  |
+       | MYSQL_MYSQL_SERVICE_HOST      | 10.1.1.1                                   |
+       | MYSQL_MYSQL_SERVICE_PORT      | 3306                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/pg_postgresqlObjectStore on XPath //*[local-name()='datasource']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pg_postgresqlObjectStorePool on XPath //*[local-name()='datasource']/@pool-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/kitchensink on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value postgresql on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pguser on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pgpass on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+
+  Scenario: Test validation's default configuration
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-postgresql=TEST                       |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+      | TEST_POSTGRESQL_SERVICE_HOST      | 10.1.1.1                                   |
+      | TEST_POSTGRESQL_SERVICE_PORT      | 5432                                       |
+      | TEST_NONXA                        | true                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hello on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value world on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='validation']/*[local-name()='validate-on-match']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='background-validation']
+
+  Scenario: Test background-validation configuration with default background-validation-milis
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-postgresql=TEST                       |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+      | TEST_POSTGRESQL_SERVICE_HOST      | 10.1.1.1                                   |
+      | TEST_POSTGRESQL_SERVICE_PORT      | 5432                                       |
+      | TEST_NONXA                        | true                                       |
+      | TEST_BACKGROUND_VALIDATION        | true                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hello on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value world on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='validate-on-match']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='validation']/*[local-name()='background-validation']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 10000 on XPath //*[local-name()='validation']/*[local-name()='background-validation-millis']
+
+  Scenario: Test background-validation configuration with custom background-validation-milis value
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-postgresql=TEST                       |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+      | TEST_POSTGRESQL_SERVICE_HOST      | 10.1.1.1                                   |
+      | TEST_POSTGRESQL_SERVICE_PORT      | 5432                                       |
+      | TEST_NONXA                        | true                                       |
+      | TEST_BACKGROUND_VALIDATION        | true                                       |
+      | TEST_BACKGROUND_VALIDATION_MILLIS | 3000                                       |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='datasource']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hello on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value world on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='validate-on-match']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='validation']/*[local-name()='background-validation']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3000 on XPath //*[local-name()='validation']/*[local-name()='background-validation-millis']
+
+  Scenario: Test invalid prefix mapping CLOUD-1743
+    When container is started with env
+      | variable                          | value                                      |
+      | DB_SERVICE_PREFIX_MAPPING         | test-microsoftsql=TEST                     |
+      | TX_SERVICE_PREFIX_MAPPING         | test-microsoftsql=TEST                     |
+      | TEST_JNDI                         | java:/jboss/datasources/testdb             |
+      | TEST_DATABASE                     | 007                                        |
+      | TEST_USERNAME                     | hello                                      |
+      | TEST_PASSWORD                     | world                                      |
+     Then container log should contain WARN DRIVER not set for datasource TEST. Datasource will not be configured.
+     And container log should not contain sed -e expression #1
+@jboss-eap-7
+
+  Scenario: CLOUD-2068, test timer datasource refresh-interval
+    When container is started with env
+      | variable                                  | value                                  |
+      | DATASOURCES                               | TEST                                   |
+      | TEST_JNDI                                 | java:/jboss/datasources/testds         |
+      | TEST_DRIVER                               | oracle                                 |
+      | TEST_USERNAME                             | tombrady                               |
+      | TEST_PASSWORD                             | password                               |
+      | TEST_URL                                  | jdbc:oracle:thin:@10.1.1.1:1521:testdb |
+      | TEST_NONXA                                | true                                   |
+      | TEST_JTA                                  | true                                   |
+      | TIMER_SERVICE_DATA_STORE                  | TEST                                   |
+      | TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL | 60000                                  |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:oracle:thin:@10.1.1.1:1521:testdb on XPath //*[local-name()='connection-url']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value oracle on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test-TEST_part on XPath //*[local-name()='database-data-store']/@partition
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 60000 on XPath //*[local-name()='database-data-store']/@refresh-interval
+
+  Scenario: CLOUD-2068, test timer datasource refresh-interval
+    When container is started with env
+      | variable                 | value                                  |
+      | DATASOURCES              | TEST                                   |
+      | TEST_JNDI                | java:/jboss/datasources/testds         |
+      | TEST_DRIVER              | oracle                                 |
+      | TEST_USERNAME            | tombrady                               |
+      | TEST_PASSWORD            | password                               |
+      | TEST_URL                 | jdbc:oracle:thin:@10.1.1.1:1521:testdb |
+      | TEST_NONXA               | true                                   |
+      | TEST_JTA                 | true                                   |
+      | TIMER_SERVICE_DATA_STORE | TEST                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:oracle:thin:@10.1.1.1:1521:testdb on XPath //*[local-name()='connection-url']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value oracle on XPath //*[local-name()='datasource']/*[local-name()='driver']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tombrady on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value password on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value test-TEST_part on XPath //*[local-name()='database-data-store']/@partition
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value -1 on XPath //*[local-name()='database-data-store']/@refresh-interval
+
+  Scenario: Test background-validation configuration with custom background-validation-milis value
+    When container is started with env
+      | variable                                  | value                |
+      | DB_SERVICE_PREFIX_MAPPING                 | test-postgresql=TEST |
+      | TEST_DATABASE                             | 007                  |
+      | TEST_USERNAME                             | hello                |
+      | TEST_PASSWORD                             | world                |
+      | TEST_POSTGRESQL_SERVICE_HOST              | 10.1.1.1             |
+      | TEST_POSTGRESQL_SERVICE_PORT              | 5432                 |
+      | TEST_NONXA                                | true                 |
+      | TEST_BACKGROUND_VALIDATION                | true                 |
+      | TEST_BACKGROUND_VALIDATION_MILLIS         | 3000                 |
+      | TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL | 60000                |
+      | TIMER_SERVICE_DATA_STORE                  | test-postgresql      |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/datasources/test_postgresql on XPath //*[local-name()='datasource']/@jndi-name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value hello on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='user-name']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value world on XPath //*[local-name()='datasource']/*[local-name()='security']/*[local-name()='password']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='validation']/*[local-name()='validate-on-match']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='validation']/*[local-name()='background-validation']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 3000 on XPath //*[local-name()='validation']/*[local-name()='background-validation-millis']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 60000 on XPath //*[local-name()='database-data-store']/@refresh-interval

--- a/tests/features/7/filters.feature
+++ b/tests/features/7/filters.feature
@@ -1,0 +1,25 @@
+@jboss-eap-7
+Feature: EAP 7 Openshift filters
+
+  Scenario: CLOUD-2877, RHDM-520, RHPAM-1434, test default filter ref name
+    When container is started with env
+      | variable                         | value      |
+      | FILTERS                          | FOO        |
+      | FOO_FILTER_RESPONSE_HEADER_NAME  | Foo-Header |
+      | FOO_FILTER_RESPONSE_HEADER_VALUE | FOO        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value Foo-Header on XPath //*[local-name()='host']/*[local-name()='filter-ref']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value Foo-Header on XPath //*[local-name()='filters']/*[local-name()='response-header']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value Foo-Header on XPath //*[local-name()='filters']/*[local-name()='response-header']/@header-name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value FOO on XPath //*[local-name()='filters']/*[local-name()='response-header']/@header-value
+
+  Scenario: CLOUD-2877, RHDM-520, RHPAM-1434, test specific filter ref name
+    When container is started with env
+      | variable                         | value      |
+      | FILTERS                          | FOO        |
+      | FOO_FILTER_REF_NAME              | foo        |
+      | FOO_FILTER_RESPONSE_HEADER_NAME  | Foo-Header |
+      | FOO_FILTER_RESPONSE_HEADER_VALUE | FOO        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value foo on XPath //*[local-name()='host']/*[local-name()='filter-ref']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value foo on XPath //*[local-name()='filters']/*[local-name()='response-header']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value Foo-Header on XPath //*[local-name()='filters']/*[local-name()='response-header']/@header-name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value FOO on XPath //*[local-name()='filters']/*[local-name()='response-header']/@header-value

--- a/tests/features/7/gc.feature
+++ b/tests/features/7/gc.feature
@@ -1,0 +1,129 @@
+@jboss-eap-7
+Feature: Openshift OpenJDK GC tests
+
+  Scenario: Check default GC configuration
+    When container is ready
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:\+ExitOnOutOfMemoryError\s
+
+  Scenario: Check GC_MIN_HEAP_FREE_RATIO GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_MIN_HEAP_FREE_RATIO           | 5      |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=5\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_MAX_HEAP_FREE_RATIO GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_MAX_HEAP_FREE_RATIO           | 50     |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=50\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_TIME_RATIO GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_TIME_RATIO                    | 5      |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=5\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_ADAPTIVE_SIZE_POLICY_WEIGHT GC configuration
+    When container is started with env
+       | variable                         | value  |
+       | GC_ADAPTIVE_SIZE_POLICY_WEIGHT   | 80     |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=80\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
+
+  Scenario: Check GC_MAX_METASPACE_SIZE GC configuration
+    When container is started with env
+       | variable                 | value  |
+       | GC_MAX_METASPACE_SIZE    | 120    |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=120m\s
+
+  Scenario: Check for adjusted heap sizes
+    When container is started with args
+      | arg       | value                                                    |
+      | mem_limit | 1073741824                                               |
+      | env_json  | {"JAVA_MAX_MEM_RATIO": 25, "JAVA_INITIAL_MEM_RATIO": 50} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms128m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx256m\s
+
+  # CLOUD-193 (mem-limit); CLOUD-459 (default heap size == max)
+  Scenario: CLOUD-193 Check for dynamic resource allocation
+    When container is started with args
+      | arg                    | value             |
+      | mem_limit              | 1073741824        |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms128m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx512m\s
+
+  # CLOUD-459 (override default heap size)
+  Scenario: CLOUD-459 Check for adjusted default heap size
+    When container is started with args
+      | arg       | value                         |
+      | mem_limit | 1073741824                    |
+      | env_json  | {"INITIAL_HEAP_PERCENT": 0.5} |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -Xms256m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -Xmx512m\s
+
+  Scenario: CLOUD-1524, test JAVA_CORE_LIMIT
+    When container is started with env
+      | variable              | value    |
+      | JAVA_CORE_LIMIT       | 3        |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=3\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=3\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s
+
+  Scenario: CLOUD-1524, test JAVA_CORE_LIMIT < CONTAINER_CORE_LIMIT
+    When container is started with args and env
+      | arg_env              | value    |
+      | arg_cpu_quota        | 20000    |
+      | arg_cpu_period       | 5000     |
+      | env_JAVA_CORE_LIMIT  | 2        |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=2\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=2\s
+     And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s
+
+  Scenario: CLOUD-1524, test JAVA_CORE_LIMIT > CONTAINER_CORE_LIMIT
+    When container is started with args and env
+      | arg_env              | value    |
+      | arg_cpu_quota        | 20000    |
+      | arg_cpu_period       | 5000     |
+      | env_JAVA_CORE_LIMIT  | 6        |
+   Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s
+
+  Scenario: CLOUD-1524, test CONTAINER_CORE_LIMIT
+    When container is started with args
+      | arg                  | value    |
+      | cpu_quota            | 20000    |
+      | cpu_period           | 5000     |
+   Then container log should match regex ^ *JAVA_OPTS: *.* -XX:ParallelGCThreads=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -Djava.util.concurrent.ForkJoinPool.common.parallelism=4\s
+    And container log should match regex ^ *JAVA_OPTS: *.* -XX:CICompilerCount=2\s

--- a/tests/features/7/hawkular.feature
+++ b/tests/features/7/hawkular.feature
@@ -1,0 +1,107 @@
+@jboss-eap-7
+Feature: OpenShift EAP Hawkular agent tests
+
+   Scenario: Check default Hawkular
+     When container is ready
+     Then container log should not contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10 
+
+   # Need to mount an actual keystore to test security-realm configuration
+   @ignore
+   Scenario: Check full Hawkular configuration
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | https://hawkular:5280/hawkular  |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+       | AB_HAWKULAR_REST_FEED_ID            | project:podid                   |
+       | AB_HAWKULAR_REST_TENANT_ID          | project                         |
+       | AB_HAWKULAR_REST_KEYSTORE           | keystore.jks                    |
+       | AB_HAWKULAR_REST_KEYSTORE_DIR       | /etc/hawkular-agent-volume      |
+       | AB_HAWKULAR_REST_KEYSTORE_PASSWORD  | 53same!                         |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+       And container log should contain hawkular.rest.tenantId = project
+       And container log should contain hawkular.rest.feedId = project:podid
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain name: HawkularRealm
+
+   Scenario: Check unsecured Hawkular configuration
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | http://hawkular:5280/hawkular   |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = http://hawkular:5280/hawkular
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain name: HawkularRealm
+
+   Scenario: Check error on Hawkular configuration without keystore
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | https://hawkular:5280/hawkular  |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+       And container log should contain WARN No AB_HAWKULAR_REST_KEYSTORE configuration defined.  HawkularRealm security-realm will not be configured and https access to the Hawkular REST service may fail.
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain name: HawkularRealm
+
+   Scenario: Check error on Hawkular configuration with partial keystore
+     When container is started with env
+       | variable                            | value                           |
+       | AB_HAWKULAR_REST_URL                | https://hawkular:5280/hawkular  |
+       | AB_HAWKULAR_REST_USER               | hawkW1nd                        |
+       | AB_HAWKULAR_REST_PASSWORD           | QSandC77!                       |
+       | AB_HAWKULAR_REST_KEYSTORE           | keystore.jks                    |
+     Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=10
+       And container log should contain hawkular.agent.in-container = true
+       And container log should contain hawkular.rest.user = hawkW1nd
+       And container log should contain -Dhawkular.rest.password=QSandC77!
+       And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+       And container log should contain WARN Partial AB_HAWKULAR_REST_KEYSTORE configuration defined.  HawkularRealm security-realm will not be configured and https access to the Hawkular REST service may fail.
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain security-realm: HawkularRealm
+       And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should not contain name: HawkularRealm
+
+  Scenario: CLOUD-1680 - CTF tests does not test all Hawkular related parameters
+    When container is started with env
+      | variable                                 | value                               |
+      | AB_HAWKULAR_REST_URL                     | https://hawkular:5280/hawkular      |
+      | AB_HAWKULAR_REST_USER                    | hawkW1nd                            |
+      | AB_HAWKULAR_REST_PASSWORD                | QSandC77!                           |
+      | AB_HAWKULAR_REST_KEYSTORE                | keystore.jks                        |
+      | AB_HAWKULAR_REST_KEYSTORE_DIR            | /etc/hawkular-agent-volume          |
+      | AB_HAWKULAR_REST_KEYSTORE_PASSWORD       | 53same!                             |
+      | AB_HAWKULAR_REST_KEYSTORE_TYPE           | pkcs12                              |
+      | AB_HAWKULAR_REST_KEY_MANAGER_ALGORITHM   | SunX509                             |
+      | AB_HAWKULAR_REST_TRUST_MANAGER_ALGORITHM | RSA                                 |
+      | AB_HAWKULAR_REST_SSL_PROTOCOL            | TLSv3                               |
+      | AB_HAWKULAR_AGENT_OPTS                   | delay=100                           |
+    Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml,delay=100
+    And container log should contain hawkular.agent.in-container = true
+    And container log should contain hawkular.rest.user = hawkW1nd
+    And container log should contain -Dhawkular.rest.password=QSandC77!
+    And container log should contain hawkular.rest.host = https://hawkular:5280/hawkular
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain keystore-type: pkcs12
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain key-manager-algorithm: SunX509
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain trust-manager-algorithm: RSA
+    And file /opt/jboss/container/hawkular/etc/hawkular-javaagent-config.yaml should contain ssl-protocol: TLSv3
+
+  Scenario: CLOUD-1680 - test only custom location of agent conf file
+    When container is started with env
+      | variable                                 | value                               |
+      | AB_HAWKULAR_REST_URL                     | https://hawkular:5280/hawkular      |
+      | AB_HAWKULAR_REST_USER                    | hawkW1nd                            |
+      | AB_HAWKULAR_REST_PASSWORD                | QSandC77!                           |
+      | AB_HAWKULAR_AGENT_CONFIG                 | /opt/jboss/container/hawkular-javaagent-config.yaml |
+    Then container log should contain -javaagent:/opt/jboss/container/hawkular/hawkular-javaagent.jar=config=/opt/jboss/container/hawkular-javaagent-config.yaml,delay=10

--- a/tests/features/7/https.feature
+++ b/tests/features/7/https.feature
@@ -1,0 +1,44 @@
+@jboss-eap-7
+Feature: Check HTTPS configuration
+
+  Scenario: Configure HTTPS
+    When container is started with env
+      | variable               | value        |
+      | EAP_HTTPS_PASSWORD     | p@ssw0rd     |
+      | EAP_HTTPS_KEYSTORE_DIR | /opt/eap     |
+      | EAP_HTTPS_KEYSTORE     | keystore.jks |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /opt/eap/keystore.jks on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@path
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value p@ssw0rd on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@keystore-password
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@socket-binding
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ApplicationRealm on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@security-realm
+
+  Scenario: Configure HTTPS with JCEKS keystore
+    When container is started with env
+      | variable            | value          |
+      | HTTPS_PASSWORD      | p@ssw0rd       |
+      | HTTPS_KEYSTORE_DIR  | /opt/eap       |
+      | HTTPS_KEYSTORE      | keystore.jceks |
+      | HTTPS_KEYSTORE_TYPE | JCEKS |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /opt/eap/keystore.jceks on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@path
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value JCEKS on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@provider
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value p@ssw0rd on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']/*[local-name()='ssl']/*[local-name()='keystore']/@keystore-password
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@socket-binding
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ApplicationRealm on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@security-realm
+
+  Scenario: Use Elytron for HTTPS
+    When container is started with env
+      | variable                      | value        |
+      | HTTPS_PASSWORD                | p@ssw0rd     |
+      | HTTPS_KEYSTORE_DIR            | /opt/eap     |
+      | HTTPS_KEYSTORE                | keystore.jks |
+      | HTTPS_KEYSTORE_TYPE           | JKS          |
+      | CONFIGURE_ELYTRON_SSL         | true         |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='security-realm'][@name="ApplicationRealm"]/*[local-name()='server-identities']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value https on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@socket-binding
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value LocalhostSslContext on XPath //*[local-name()='server'][@name="default-server"]/*[local-name()='https-listener']/@ssl-context
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value p@ssw0rd on XPath //*[local-name()='tls']/*[local-name()='key-stores']/*[local-name()='key-store'][@name="LocalhostKeyStore"]/*[local-name()='credential-reference']/@clear-text
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value JKS on XPath //*[local-name()='tls']/*[local-name()='key-stores']/*[local-name()='key-store'][@name="LocalhostKeyStore"]/*[local-name()='implementation']/@type
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /opt/eap/keystore.jks on XPath //*[local-name()='tls']/*[local-name()='key-stores']/*[local-name()='key-store'][@name="LocalhostKeyStore"]/*[local-name()='file']/@path

--- a/tests/features/7/jgroups.feature
+++ b/tests/features/7/jgroups.feature
@@ -1,0 +1,34 @@
+@jboss-eap-7
+Feature: Openshift EAP jgroups
+
+  # CLOUD-336
+  Scenario: Check if jgroups is secure
+    When container is started with env
+       | variable                 | value    |
+       | JGROUPS_CLUSTER_PASSWORD | asdfasdf |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+
+    Then container log should contain WFLYSRV0025:
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='auth-protocol'][@type='AUTH']
+
+  Scenario: Check jgroups encryption does not create invalid configuration with missing name
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WFLYSRV0025:
+     And available container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
+
+  Scenario: Check jgroups encryption does not create invalid configuration with missing password
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+    Then container log should contain WFLYSRV0025:
+     And available container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.

--- a/tests/features/7/messaging.feature
+++ b/tests/features/7/messaging.feature
@@ -1,0 +1,38 @@
+@jboss-eap-7
+Feature: Openshift EAP Messaging Tests
+
+  Scenario: deploys the helloworld-mdb example, then checks if it's deployed properly.
+    Given s2i build https://github.com/jboss-developer/jboss-eap-quickstarts from helloworld-mdb using 7.0.x
+    Then container log should contain Bound messaging object to jndi name java:/queue/HELLOWORLDMDBQueue
+    Then container log should contain Bound messaging object to jndi name java:/topic/HELLOWORLDMDBTopic
+    Then container log should contain Started message driven bean 'HelloWorldQueueMDB' with 'activemq-ra.rar' resource adapter
+    Then container log should contain Started message driven bean 'HelloWorldQTopicMDB' with 'activemq-ra.rar' resource adapter
+
+  Scenario: Check if thread pool default values respect cgroup limits
+    When container is started with args
+      | arg        | value    |
+      | cpu_quota  | 100000   |
+      | cpu_period | 100000   |
+    Then container log should contain -Dactivemq.artemis.client.global.thread.pool.max.size=8
+    Then container log should contain -Dactivemq.artemis.client.global.scheduled.thread.pool.core.size=5
+
+  Scenario: Check if thread pool size with CONTAINER_CORE_LIMIT (CLOUD-2052)
+    When container is started with env
+      | variable              | value    |
+      | CONTAINER_CORE_LIMIT  | 4        |
+    Then container log should contain activemq.artemis.client.global.thread.pool.max.size = 32
+
+  Scenario: Check if thread pool size with CONTAINER_CORE_LIMIT > JAVA_CORE_LIMIT (CLOUD-2052)
+    When container is started with env
+      | variable              | value    |
+      | CONTAINER_CORE_LIMIT  | 4        |
+      | JAVA_CORE_LIMIT       | 3        |
+    Then container log should contain activemq.artemis.client.global.thread.pool.max.size = 24
+
+  Scenario: Check if thread pool size with CONTAINER_CORE_LIMIT < JAVA_CORE_LIMIT (CLOUD-2052)
+    When container is started with env
+      | variable              | value    |
+      | CONTAINER_CORE_LIMIT  | 3        |
+      | JAVA_CORE_LIMIT       | 4        |
+    Then container log should contain activemq.artemis.client.global.thread.pool.max.size = 24
+

--- a/tests/features/7/resource_adapters.feature
+++ b/tests/features/7/resource_adapters.feature
@@ -1,0 +1,175 @@
+@jboss-eap-7
+Feature: EAP Openshift resource adapters
+
+  Scenario: Test resource adapter extension
+    When container is started with env
+       | variable                         | value                                                        |
+       | RESOURCE_ADAPTERS                | TEST_1                                                       |
+       | TEST_1_ID                        | fileQS                                                       |
+       | TEST_1_MODULE_SLOT               | main                                                         |
+       | TEST_1_MODULE_ID                 | org.jboss.teiid.resource-adapter.file                        |
+       | TEST_1_CONNECTION_CLASS          | org.teiid.resource.adapter.file.FileManagedConnectionFactory |
+       | TEST_1_CONNECTION_JNDI           | java:/marketdata-file                                        |
+       | TEST_1_PROPERTY_ParentDirectory  | /home/jboss/source/injected/injected-files/data              |
+       | TEST_1_PROPERTY_AllowParentPaths | true                                                         |
+       | TEST_1_POOL_MIN_SIZE             | 1                                                            |
+       | TEST_1_POOL_MAX_SIZE             | 5                                                            |
+       | TEST_1_POOL_PREFILL              | false                                                        |
+       | TEST_1_POOL_FLUSH_STRATEGY       | EntirePool                                                   |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value fileQS on XPath //*[local-name()='resource-adapter']/@id
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.jboss.teiid.resource-adapter.file on XPath //*[local-name()='resource-adapter']/*[local-name()='module']/@id
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.teiid.resource.adapter.file.FileManagedConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@class-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /home/jboss/source/injected/injected-files/data on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='config-property'][@name="ParentDirectory"]
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='prefill']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value EntirePool on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='flush-strategy']
+
+  Scenario: Test warning no module slot is provided
+    When container is started with env
+       | variable                       | value                                                        |
+       | RESOURCE_ADAPTERS              | TEST                                                         |
+       | TEST_CONNECTION_CLASS          | org.teiid.resource.adapter.file.FileManagedConnectionFactory |
+       | TEST_CONNECTION_JNDI           | java:/marketdata-file                                        |
+       | TEST_PROPERTY_ParentDirectory  | /home/jboss/source/injected/injected-files/data              |
+       | TEST_PROPERTY_AllowParentPaths | true                                                         |
+    Then container log should contain WARN TEST_ID is missing from resource adapter configuration, defaulting to TEST
+    And container log should contain WARN TEST_MODULE_SLOT is missing from resource adapter configuration, defaulting to main
+    And container log should contain WARN TEST_MODULE_ID and TEST_ARCHIVE are missing from resource adapter configuration. One is required. Resource adapter will not be configured
+
+   Scenario: Test AMQ resource adapter extension
+    When container is started with env
+       | variable                                | value                                                        |
+       | MQ_SERVICE_PREFIX_MAPPING               | eap-app-amq=DUMMY                                            |
+       | DUMMY_JNDI                              | java:/ConnectionFactory                                      |
+       | RESOURCE_ADAPTERS                       | TEST_1                                                       |
+       | TEST_1_ID                               | activemq-rar.rar                                             |
+       | TEST_1_ARCHIVE                          | activemq-rar.rar                                             |
+       | TEST_1_TRANSACTION_SUPPORT              | XATransaction                                                |
+       | TEST_1_CONNECTION_CLASS                 | org.apache.activemq.ra.ActiveMQManagedConnectionFactory      |
+       | TEST_1_CONNECTION_JNDI                  | java:/ConnectionFactory                                      |
+       | TEST_1_PROPERTY_ServerUrl               | tcp://1.2.3.4:61616?jms.rmIdFromConnectionId=true            |
+       | TEST_1_PROPERTY_UserName                | tombrady                                                     |
+       | TEST_1_PROPERTY_Password                | P@ssword1                                                    |
+       | TEST_1_POOL_XA                          | true                                                         |
+       | TEST_1_POOL_MIN_SIZE                    | 1                                                            |
+       | TEST_1_POOL_MAX_SIZE                    | 5                                                            |
+       | TEST_1_POOL_PREFILL                     | false                                                        |
+       | TEST_1_POOL_IS_SAME_RM_OVERRIDE         | false                                                        |
+       | TEST_1_ADMIN_OBJECTS                    | queue,topic                                                  |
+       | TEST_1_ADMIN_OBJECT_queue_CLASS_NAME    | org.apache.activemq.command.ActiveMQQueue                    |
+       | TEST_1_ADMIN_OBJECT_queue_PHYSICAL_NAME | queue/HELLOWORLDMDBQueue                                     |
+       | TEST_1_ADMIN_OBJECT_topic_CLASS_NAME    | org.apache.activemq.command.ActiveMQTopic                    |
+       | TEST_1_ADMIN_OBJECT_topic_PHYSICAL_NAME | queue/HELLOWORLDMDBTopic                                     |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/@id
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/*[local-name()='archive']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.ra.ActiveMQManagedConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@class-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/ConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@jndi-name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='prefill']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='is-same-rm-override']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQTopic on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@class-name
+
+  Scenario:   Scenario: CLOUD-2455, test tracking configuration
+    When container is started with env
+      | variable                                | value                                                        |
+      | MQ_SERVICE_PREFIX_MAPPING               | eap-app-amq=DUMMY                                            |
+      | DUMMY_JNDI                              | java:/ConnectionFactory                                      |
+      | RESOURCE_ADAPTERS                       | TEST_1                                                       |
+      | TEST_1_ID                               | activemq-rar.rar                                             |
+      | TEST_1_ARCHIVE                          | activemq-rar.rar                                             |
+      | TEST_1_TRANSACTION_SUPPORT              | XATransaction                                                |
+      | TEST_1_CONNECTION_CLASS                 | org.apache.activemq.ra.ActiveMQManagedConnectionFactory      |
+      | TEST_1_CONNECTION_JNDI                  | java:/ConnectionFactory                                      |
+      | TEST_1_PROPERTY_ServerUrl               | tcp://1.2.3.4:61616?jms.rmIdFromConnectionId=true            |
+      | TEST_1_PROPERTY_UserName                | tombrady                                                     |
+      | TEST_1_PROPERTY_Password                | P@ssword1                                                    |
+      | TEST_1_POOL_XA                          | true                                                         |
+      | TEST_1_POOL_MIN_SIZE                    | 1                                                            |
+      | TEST_1_POOL_MAX_SIZE                    | 5                                                            |
+      | TEST_1_POOL_PREFILL                     | false                                                        |
+      | TEST_1_POOL_IS_SAME_RM_OVERRIDE         | false                                                        |
+      | TEST_1_ADMIN_OBJECTS                    | queue,topic                                                  |
+      | TEST_1_ADMIN_OBJECT_queue_CLASS_NAME    | org.apache.activemq.command.ActiveMQQueue                    |
+      | TEST_1_ADMIN_OBJECT_queue_PHYSICAL_NAME | queue/HELLOWORLDMDBQueue                                     |
+      | TEST_1_ADMIN_OBJECT_topic_CLASS_NAME    | org.apache.activemq.command.ActiveMQTopic                    |
+      | TEST_1_ADMIN_OBJECT_topic_PHYSICAL_NAME | queue/HELLOWORLDMDBTopic                                     |
+      | TEST_1_TRACKING                         | false                                                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/@id
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/*[local-name()='archive']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.ra.ActiveMQManagedConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@class-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/ConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='prefill']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='is-same-rm-override']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQTopic on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@class-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@tracking
+
+  Scenario: CLOUD-2455, test tracking configuration
+    When container is started with env
+      | variable                         | value                                                        |
+      | RESOURCE_ADAPTERS                | TEST_1                                                       |
+      | TEST_1_ID                        | fileQS                                                       |
+      | TEST_1_MODULE_SLOT               | main                                                         |
+      | TEST_1_MODULE_ID                 | org.jboss.teiid.resource-adapter.file                        |
+      | TEST_1_CONNECTION_CLASS          | org.teiid.resource.adapter.file.FileManagedConnectionFactory |
+      | TEST_1_CONNECTION_JNDI           | java:/marketdata-file                                        |
+      | TEST_1_PROPERTY_ParentDirectory  | /home/jboss/source/injected/injected-files/data              |
+      | TEST_1_PROPERTY_AllowParentPaths | true                                                         |
+      | TEST_1_POOL_MIN_SIZE             | 1                                                            |
+      | TEST_1_POOL_MAX_SIZE             | 5                                                            |
+      | TEST_1_POOL_PREFILL              | false                                                        |
+      | TEST_1_POOL_FLUSH_STRATEGY       | EntirePool                                                   |
+      | TEST_1_TRACKING                  | false                                                        |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value fileQS on XPath //*[local-name()='resource-adapter']/@id
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.jboss.teiid.resource-adapter.file on XPath //*[local-name()='resource-adapter']/*[local-name()='module']/@id
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.teiid.resource.adapter.file.FileManagedConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@class-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /home/jboss/source/injected/injected-files/data on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='config-property'][@name="ParentDirectory"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='min-pool-size']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 5 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='max-pool-size']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='prefill']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value EntirePool on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='pool']/*[local-name()='flush-strategy']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@tracking
+
+  Scenario: CLOUD-2455, test tracking configuration
+    When container is started with env
+      | variable                      | value               |
+      | MQ_SERVICE_PREFIX_MAPPING     | eap-app-amq=MQ      |
+      | MQ_JNDI                       | java:jboss/mq/jndi  |
+      | MQ_USERNAME                   | testUser            |
+      | MQ_PASSWORD                   | testPass            |
+      | MQ_PROTOCOL                   | tcp                 |
+      | MQ_QUEUES                     | foo                 |
+      | MQ_TOPICS                     | bar                 |
+      | MQ_SERIALIZABLE_PACKAGES      | foo.bar             |
+      | EAP_APP_AMQ_TCP_SERVICE_HOST  | 10.10.10.10         |
+      | EAP_APP_AMQ_TCP_SERVICE_PORT  | 8000                |
+      | MQ_TRACKING                   | false               |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/@id
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value activemq-rar.rar on XPath //*[local-name()='resource-adapter']/*[local-name()='archive']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value XATransaction on XPath //*[local-name()='resource-adapter']/*[local-name()='transaction-support']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value testUser on XPath //*[local-name()='resource-adapter']/*[local-name()='config-property'][@name="UserName"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value testPass on XPath //*[local-name()='resource-adapter']/*[local-name()='config-property'][@name="Password"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value tcp://10.10.10.10:8000?jms.rmIdFromConnectionId=true on XPath //*[local-name()='resource-adapter']/*[local-name()='config-property'][@name="ServerUrl"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@tracking
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.ra.ActiveMQManagedConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@class-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:jboss/mq/jndi on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@enabled
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value eap-app-amq-ConnectionFactory on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@pool-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='min-pool-size']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 20 on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='max-pool-size']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value testUser on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='recovery']/*[local-name()='recover-credential']/*[local-name()='user-name']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value testPass on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='recovery']/*[local-name()='recover-credential']/*[local-name()='password']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQQueue on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@class-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/queue/foo on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@use-java-context
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value queue/foo on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@pool-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value queue/foo on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/*[local-name()='config-property'][@name="PhysicalName"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.apache.activemq.command.ActiveMQTopic on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@class-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/topic/bar on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@jndi-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value topic/bar on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/@pool-name
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value topic/bar on XPath //*[local-name()='resource-adapter']/*[local-name()='admin-objects']/*[local-name()='admin-object']/*[local-name()='config-property'][@name="PhysicalName"]
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/*[local-name()='xa-pool']/*[local-name()='prefill']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='resource-adapter']/*[local-name()='connection-definitions']/*[local-name()='connection-definition']/@tracking

--- a/tests/features/7/s2i.feature
+++ b/tests/features/7/s2i.feature
@@ -13,14 +13,15 @@ Feature: Openshift EAP s2i tests
   # Append user-supplied arguments (CLOUD-412)
   # Allow the user to clear down the maven repository after running s2i (CLOUD-413)
   Scenario: Test to ensure that maven is run with -Djava.net.preferIPv4Stack=true and user-supplied arguments, even when MAVEN_ARGS is overridden, and doesn't clear the local repository after the build
-    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+    Given s2i build https://github.com/jboss-developer/jboss-eap-quickstarts from helloworld using openshift
        | variable          | value                                                                                  |
-       | MAVEN_ARGS        | -e -P jboss-eap-repository-insecure,-securecentral,insecurecentral -DskipTests package |
+       | MAVEN_ARGS        | -e -P jboss-eap-repository-insecure,-securecentral,insecurecentral -Dcom.redhat.xpaas.repo.jbossorg -DskipTests package |
        | MAVEN_ARGS_APPEND | -Dfoo=bar                                                                              |
-    Then s2i build log should contain -Djava.net.preferIPv4Stack=true
-    Then s2i build log should contain -Dfoo=bar
-    Then s2i build log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
-    Then run sh -c 'test -d /tmp/artifacts/m2/org && echo all good' in container and immediately check its output for all good
+    Then container log should contain WFLYSRV0025
+    And run sh -c 'test -d /tmp/artifacts/m2/org && echo all good' in container and immediately check its output for all good
+    And s2i build log should contain -Djava.net.preferIPv4Stack=true
+    And s2i build log should contain -Dfoo=bar
+    And s2i build log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 
   # CLOUD-458
   Scenario: Test s2i build with environment only

--- a/tests/features/7/s2i.feature
+++ b/tests/features/7/s2i.feature
@@ -1,0 +1,99 @@
+@jboss-eap-7
+Feature: Openshift EAP s2i tests
+
+  Scenario: deploys the binary example, then checks if both war files are deployed.
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from binary
+    Then container log should contain WFLYSRV0025
+    And available container log should contain WFLYSRV0010: Deployed "node-info.war"
+    And file /opt/eap/standalone/deployments/node-info.war should exist
+    And available container log should contain WFLYSRV0010: Deployed "top-level.war"
+    And file /opt/eap/standalone/deployments/top-level.war should exist
+
+  # Always force IPv4 (CLOUD-188)
+  # Append user-supplied arguments (CLOUD-412)
+  # Allow the user to clear down the maven repository after running s2i (CLOUD-413)
+  Scenario: Test to ensure that maven is run with -Djava.net.preferIPv4Stack=true and user-supplied arguments, even when MAVEN_ARGS is overridden, and doesn't clear the local repository after the build
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable          | value                                                                                  |
+       | MAVEN_ARGS        | -e -P jboss-eap-repository-insecure,-securecentral,insecurecentral -DskipTests package |
+       | MAVEN_ARGS_APPEND | -Dfoo=bar                                                                              |
+    Then s2i build log should contain -Djava.net.preferIPv4Stack=true
+    Then s2i build log should contain -Dfoo=bar
+    Then s2i build log should contain -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+    Then run sh -c 'test -d /tmp/artifacts/m2/org && echo all good' in container and immediately check its output for all good
+
+  # CLOUD-458
+  Scenario: Test s2i build with environment only
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from environment-only
+    Then run sh -c 'echo FOO is $FOO' in container and check its output for FOO is Iedieve8
+    And s2i build log should not contain cp: cannot stat '/tmp/src/*': No such file or directory
+
+  # CLOUD-579
+  Scenario: Test that maven is executed in batch mode
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+    Then s2i build log should contain --batch-mode
+    And s2i build log should not contain \r
+
+  # CLOUD-807
+  Scenario: Test if the container have the JavaScript engine available
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from eap-tests/jsengine
+    Then container log should contain Engine found: jdk.nashorn.api.scripting.NashornScriptEngine
+    And container log should contain Engine class provider found.
+    And container log should not contain JavaScript engine not found.
+
+  # Always force IPv4 (CLOUD-188)
+  # Append user-supplied arguments (CLOUD-412)
+  # Allow the user to clear down the maven repository after running s2i (CLOUD-413)
+  Scenario: Test to ensure that maven is run with -Djava.net.preferIPv4Stack=true and user-supplied arguments, and clears the local repository after the build
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable          | value                      |
+       | MAVEN_ARGS_APPEND | -Dfoo=bar                  |
+       | MAVEN_LOCAL_REPO  | /home/jboss/.m2/repository |
+       | MAVEN_CLEAR_REPO  | true                       |
+    Then s2i build log should contain -Djava.net.preferIPv4Stack=true
+    Then s2i build log should contain -Dfoo=bar
+    Then run sh -c 'test -d /home/jboss/.m2/repository/org && echo oops || echo all good' in container and immediately check its output for all good
+
+  #CLOUD-512: Copy configuration files, after the build has had a chance to generate them.
+  Scenario: custom configuration deployment for existing and dynamically created files
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from eap-dynamic-configuration
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='root-logger']/*[local-name()='level'][@name='DEBUG']
+
+  # CLOUD-1145 - base test
+  Scenario: Check custom war file was successfully deployed via CUSTOM_INSTALL_DIRECTORIES
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from custom-install-directories
+      | variable   | value                    |
+      | CUSTOM_INSTALL_DIRECTORIES | custom   |
+    Then file /opt/eap/standalone/deployments/node-info.war should exist
+
+  # CLOUD-1145 - CSV test
+  Scenario: Check all modules are successfully deployed using comma-separated CUSTOM_INSTALL_DIRECTORIES value
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from custom-install-directories
+      | variable   | value                    |
+      | CUSTOM_INSTALL_DIRECTORIES | foo,bar  |
+    Then file /opt/eap/standalone/deployments/foo.jar should exist
+    Then file /opt/eap/standalone/deployments/bar.jar should exist
+
+  # https://issues.jboss.org/browse/CLOUD-1168
+  Scenario: Make sure that custom data is being copied
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from helloworld-ws
+      | variable    | value                           |
+      | APP_DATADIR | src/main/java/org/jboss/as/quickstarts/wshelloworld |
+    Then file /opt/eap/standalone/data/HelloWorldService.java should exist
+     And file /opt/eap/standalone/data/HelloWorldServiceImpl.java should exist
+     And run stat -c "%a %n" /opt/eap/standalone/data in container and immediately check its output contains 775 /opt/eap/standalone/data
+
+  # https://issues.jboss.org/browse/CLOUD-1143
+  Scenario: Make sure that custom data is being copied even if no source code is found
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from binary
+      | variable    | value                           |
+      | APP_DATADIR | deployments |
+    Then file /opt/eap/standalone/data/node-info.war should exist
+     And run stat -c "%a %n" /opt/eap/standalone/data in container and immediately check its output contains 775 /opt/eap/standalone/data
+
+  Scenario: Make sure SCRIPT_DEBUG triggers set -x in build
+    Given s2i build https://github.com/jboss-openshift/openshift-examples.git from binary
+      | variable     | value       |
+      | APP_DATADIR  | deployments |
+      | SCRIPT_DEBUG | true        |
+    Then s2i build log should contain + log_info 'Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed'

--- a/tests/features/7/security_domains.feature
+++ b/tests/features/7/security_domains.feature
@@ -1,0 +1,108 @@
+@jboss-eap-7
+Feature: EAP Openshift security domains
+
+  Scenario: check security-domain configured
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable           | value       |
+       | SECDOMAIN_NAME | HiThere     |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/roles.properties']
+
+  @ignore
+  # ignored for now, there are additional domains that match this in the default config now
+  Scenario: check security-domain unconfigured
+    When container is started with env
+       | variable                  | value       |
+       | UNRELATED_ENV_VARIABLE    | whatever    |
+    Then container log should contain Running jboss-eap-
+     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <!-- no additional security domains configured -->
+    # 3 OOTB are: jboss-web-policy; jboss-ejb-policy; other
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='subsystem'][/*[local-name()='security-domains']/*[local-name()='security-domain']
+
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='subsystem'][@xmlns='urn:jboss:domain:security:2.0']/*[local-name()='security-domains']/*[local-name()='security-domain']
+
+  Scenario: check security-domain custom user properties
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | SECDOMAIN_NAME              | HiThere               |
+       | SECDOMAIN_USERS_PROPERTIES  | otherusers.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='usersProperties'][@value='${jboss.server.config.dir}/otherusers.properties']
+
+  Scenario: check security-domain custom role properties
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | SECDOMAIN_NAME              | HiThere               |
+       | SECDOMAIN_ROLES_PROPERTIES  | otherroles.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/otherroles.properties']
+
+  # CLOUD-431
+  Scenario: check security-domain custom role and user properties specified as absolute path
+    When container is started with env
+       | variable                        | value                 |
+       | SECDOMAIN_NAME              | HiThere                   |
+       | SECDOMAIN_ROLES_PROPERTIES  | /opt/eap/standalone/configuration/application-roles.properties |
+       | SECDOMAIN_USERS_PROPERTIES  | /opt/eap/standalone/configuration/application-users.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /opt/eap/standalone/configuration/application-roles.properties on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties']/@value
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /opt/eap/standalone/configuration/application-users.properties on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='usersProperties']/@value
+
+  Scenario: check security-domain classic login module
+    When container is started with env
+      | variable                        | value                        |
+      | SECDOMAIN_NAME                  | jdg-openshift                |
+      | SECDOMAIN_USERS_PROPERTIES      | application-users.properties |
+      | SECDOMAIN_ROLES_PROPERTIES      | application-roles.properties |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value UsersRoles on XPath //*[local-name()='security-domain'][@name='jdg-openshift']//*[local-name()='login-module']/@code
+
+  Scenario: check security-domain realm login module
+    When container is started with env
+      | variable                        | value                        |
+      | SECDOMAIN_NAME                  | jdg-openshift                |
+      | SECDOMAIN_LOGIN_MODULE          | RealmUsersRoles              |
+      | SECDOMAIN_USERS_PROPERTIES      | application-users.properties |
+      | SECDOMAIN_ROLES_PROPERTIES      | application-roles.properties |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value RealmUsersRoles on XPath //*[local-name()='security-domain'][@name='jdg-openshift']//*[local-name()='login-module']/@code
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ApplicationRealm on XPath //*[local-name()='security-domain'][@name='jdg-openshift']//*[local-name()='login-module']/*[local-name()='module-option'][@name='realm']/@value
+
+  Scenario: check security-domain configured with prefix
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable           | value       |
+       | EAP_SECDOMAIN_NAME | HiThere     |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/roles.properties']
+
+  @ignore
+  # matches additional security-domain elements, needs to be revisited
+  Scenario: check security-domain unconfigured with prefix
+    When container is started with env
+       | variable                  | value       |
+       | UNRELATED_ENV_VARIABLE    | whatever    |
+    Then file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <!-- no additional security domains configured -->
+    # 3 OOTB are: jboss-web-policy; jboss-ejb-policy; other
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 3 elements on XPath //*[local-name()='security-domain']
+
+  Scenario: check security-domain custom user properties with prefix
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | EAP_SECDOMAIN_NAME              | HiThere               |
+       | EAP_SECDOMAIN_USERS_PROPERTIES  | otherusers.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='usersProperties'][@value='${jboss.server.config.dir}/otherusers.properties']
+
+  Scenario: check security-domain custom role properties with prefix
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from security-custom-configuration with env
+       | variable                        | value                 |
+       | EAP_SECDOMAIN_NAME              | HiThere               |
+       | EAP_SECDOMAIN_ROLES_PROPERTIES  | otherroles.properties |
+     Then container log should contain Running jboss-eap-
+      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='security-domain'][@name='HiThere'][@cache-type='default']/*[local-name()='authentication']/*[local-name()='login-module']/*[local-name()='module-option'][@name='rolesProperties'][@value='${jboss.server.config.dir}/otherroles.properties']
+
+  Scenario: check security-domain unconfigured
+    When container is started with env
+       | variable                  | value       |
+       | UNRELATED_ENV_VARIABLE    | whatever    |
+    Then container log should contain Running jboss-eap-
+     And file /opt/eap/standalone/configuration/standalone-openshift.xml should contain <!-- no additional security domains configured -->
+

--- a/tests/features/7/shutdown.feature
+++ b/tests/features/7/shutdown.feature
@@ -1,0 +1,74 @@
+@jboss-eap-7
+Feature: Openshift EAP shutdown tests
+
+  Scenario: Check if image shuts down with TERM signal
+    When container is ready
+    Then container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container once
+    And container log should contain received TERM signal
+    And container log should contain WFLYSRV0050
+
+  Scenario: Check if image does not shutdown with TERM signal when CLI_GRACEFUL_SHUTDOWN is set
+    When container is started with env
+       | variable                  | value           |
+       | CLI_GRACEFUL_SHUTDOWN     | true            |
+    Then container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container once
+    And container log should not contain received TERM signal
+    And container log should not contain WFLYSRV0050
+
+  Scenario: Check if image shuts down with cli when CLI_GRACEFUL_SHUTDOWN is set
+    When container is started with env
+       | variable                  | value           |
+       | CLI_GRACEFUL_SHUTDOWN     | true            |
+    Then container log should contain WFLYSRV0025
+    And run /opt/eap/bin/jboss-cli.sh -c "shutdown --timeout=60" in container once
+    And container log should not contain received TERM signal
+    And container log should contain WFLYSRV0050
+
+  Scenario: Check if image shuts down cleanly with TERM signal
+    When container is ready
+    Then container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container once
+    And container log should contain received TERM signal
+    And container log should contain WFLYSRV0241
+    And container log should contain WFLYSRV0050
+
+  Scenario: Check if image shuts down with TERM signal when split
+    When container is started with env
+       | variable                  | value           |
+       | SPLIT_DATA                | true            |
+    Then container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container once
+    And container log should contain received TERM signal
+    And container log should contain WFLYSRV0050
+
+  Scenario: Check if image does not shutdown with TERM signal when CLI_GRACEFUL_SHUTDOWN is set when split
+    When container is started with env
+       | variable                  | value           |
+       | CLI_GRACEFUL_SHUTDOWN     | true            |
+       | SPLIT_DATA                | true            |
+    Then container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container once
+    And container log should not contain received TERM signal
+    And container log should not contain WFLYSRV0050
+
+  Scenario: Check if image shuts down with cli when CLI_GRACEFUL_SHUTDOWN is set when split
+    When container is started with env
+       | variable                  | value           |
+       | CLI_GRACEFUL_SHUTDOWN     | true            |
+       | SPLIT_DATA                | true            |
+    Then container log should contain WFLYSRV0025
+    And run /opt/eap/bin/jboss-cli.sh -c "shutdown --timeout=60" in container once
+    And container log should not contain received TERM signal
+    And container log should contain WFLYSRV0050
+
+  Scenario: Check if image shuts down cleanly with TERM signal when split
+    When container is started with env
+       | variable                  | value           |
+       | SPLIT_DATA                | true            |
+    Then container log should contain WFLYSRV0025
+    And run kill -TERM 1 in container once
+    And container log should contain received TERM signal
+    And container log should contain WFLYSRV0241
+    And container log should contain WFLYSRV0050

--- a/tests/features/7/sso.feature
+++ b/tests/features/7/sso.feature
@@ -1,0 +1,80 @@
+@jboss-eap-7
+Feature: OpenShift EAP SSO tests
+
+   Scenario: deploys the keycloak examples, then checks if it's deployed.
+     Given XML namespaces
+       | prefix | url                          |
+       | ns     | urn:jboss:domain:keycloak:1.1 |
+     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts using 7.0.x-ose
+       | variable               | value                                            |
+       | ARTIFACT_DIR           | app-jee-jsp/target,app-profile-jee-jsp/target |
+       | SSO_REALM         | demo    |
+       | SSO_PUBLIC_KEY    | MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiLezsNQtZSaJvNZXTmjhlpIJnnwgGL5R1vkPLdt7odMgDzLHQ1h4DlfJPuPI4aI8uo8VkSGYQXWaOGUh3YJXtdO1vcym1SuP8ep6YnDy9vbUibA/o8RW6Wnj3Y4tqShIfuWf3MEsiH+KizoIJm6Av7DTGZSGFQnZWxBEZ2WUyFt297aLWuVM0k9vHMWSraXQo78XuU3pxrYzkI+A4QpeShg8xE7mNrs8g3uTmc53KR45+wW1icclzdix/JcT6YaSgLEVrIR9WkkYfEGj3vSrOzYA46pQe6WQoenLKtIDFmFDPjhcPoi989px9f+1HCIYP0txBS/hnJZaPdn5/lEUKQIDAQAB  |
+       | SSO_URL           | http://localhost:8080/auth    |
+    Then container log should contain WFLYSRV0010: Deployed "app-profile-jsp.war"
+    Then container log should contain WFLYSRV0010: Deployed "app-jsp.war"
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value demo on XPath //ns:realm/@name
+
+   Scenario: deploys the keycloak examples using secure-deployments then checks if it's deployed.
+     Given XML namespaces
+       | prefix | url                          |
+       | ns     | urn:jboss:domain:keycloak:1.1 |
+     Given s2i build http://github.com/bdecoste/keycloak-examples using securedeployments
+       | variable                   | value                                            |
+       | ARTIFACT_DIR               | app-profile-jee-saml/target,app-profile-jee/target |
+    Then container log should contain WFLYSRV0010: Deployed "app-profile-jee.war"
+    Then container log should contain WFLYSRV0010: Deployed "app-profile-jee-saml.war"
+
+   Scenario: Check default keycloak config
+     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts using 7.0.x-ose
+       | variable               | value                                                                     |
+       | ARTIFACT_DIR           | app-jee-jsp/target,service-jee-jaxrs/target,app-profile-jee-jsp/target,app-profile-saml-jee-jsp/target    |
+       | SSO_REALM              | demo                                                                      |
+       | SSO_PUBLIC_KEY         | MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiLezsNQtZSaJvNZXTmjhlpIJnnwgGL5R1vkPLdt7odMgDzLHQ1h4DlfJPuPI4aI8uo8VkSGYQXWaOGUh3YJXtdO1vcym1SuP8ep6YnDy9vbUibA/o8RW6Wnj3Y4tqShIfuWf3MEsiH+KizoIJm6Av7DTGZSGFQnZWxBEZ2WUyFt297aLWuVM0k9vHMWSraXQo78XuU3pxrYzkI+A4QpeShg8xE7mNrs8g3uTmc53KR45+wW1icclzdix/JcT6YaSgLEVrIR9WkkYfEGj3vSrOzYA46pQe6WQoenLKtIDFmFDPjhcPoi989px9f+1HCIYP0txBS/hnJZaPdn5/lEUKQIDAQAB  |
+       | SSO_URL                | http://localhost:8080/auth    |
+    Then container log should contain Deployed "service.war"
+    And container log should contain Deployed "app-profile-jsp.war"
+    And container log should contain Deployed "app-jsp.war"
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value demo on XPath //*[local-name()='realm']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-cors']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value false on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='bearer-only']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-basic-auth'] 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value http://localhost:8080/auth on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='auth-server-url']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value service.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@entityID
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value EXTERNAL on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@sslPolicy
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value / on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@logoutPage    
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='Keys']/*[local-name()='Key']/@signing 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value idp on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='IDP']/@entityID 
+     
+  Scenario: Check custom keycloak config
+     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts using 7.0.x-ose
+       | variable               | value                                                                     |
+       | ARTIFACT_DIR           | app-jee-jsp/target,service-jee-jaxrs/target,app-profile-jee-jsp/target,app-profile-saml-jee-jsp/target    |
+       | SSO_REALM              | demo                                                                      |
+       | SSO_PUBLIC_KEY         | MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiLezsNQtZSaJvNZXTmjhlpIJnnwgGL5R1vkPLdt7odMgDzLHQ1h4DlfJPuPI4aI8uo8VkSGYQXWaOGUh3YJXtdO1vcym1SuP8ep6YnDy9vbUibA/o8RW6Wnj3Y4tqShIfuWf3MEsiH+KizoIJm6Av7DTGZSGFQnZWxBEZ2WUyFt297aLWuVM0k9vHMWSraXQo78XuU3pxrYzkI+A4QpeShg8xE7mNrs8g3uTmc53KR45+wW1icclzdix/JcT6YaSgLEVrIR9WkkYfEGj3vSrOzYA46pQe6WQoenLKtIDFmFDPjhcPoi989px9f+1HCIYP0txBS/hnJZaPdn5/lEUKQIDAQAB  |
+       | SSO_URL                | http://localhost:8080/auth    |
+       | SSO_ENABLE_CORS        | true                          |
+       | SSO_BEARER_ONLY        | true                          |
+       | SSO_SAML_LOGOUT_PAGE   | /tombrady                     |
+    Then container log should contain Deployed "service.war"
+    And container log should contain Deployed "app-profile-jsp.war"
+    And container log should contain Deployed "app-jsp.war"
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value demo on XPath //*[local-name()='realm']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-cors']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='bearer-only']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='enable-basic-auth'] 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value http://localhost:8080/auth on XPath //*[local-name()='secure-deployment'][@name="app-jsp.war"]/*[local-name()='auth-server-url']
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-jsp.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value service.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml.war on XPath //*[local-name()='secure-deployment']/@name
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value app-profile-saml on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@entityID
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value EXTERNAL on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@sslPolicy
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /tombrady on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@logoutPage       
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='Keys']/*[local-name()='Key']/@signing 
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value idp on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='IDP']/@entityID 
+     

--- a/tests/features/7/variable_expansion.feature
+++ b/tests/features/7/variable_expansion.feature
@@ -1,0 +1,61 @@
+@jboss-eap-7
+Feature: Check correct variable expansion used
+  Scenario: Set EAP_ADMIN_USERNAME to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_ADMIN_PASSWORD | p@ssw0rd                         |
+      | EAP_ADMIN_USERNAME |                                  |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set ADMIN_USERNAME to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_ADMIN_PASSWORD | p@ssw0rd                         |
+      | ADMIN_USERNAME     |                                  |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set ADMIN_PASSWORD to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_ADMIN_PASSWORD | p@ssw0rd                         |
+      | ADMIN_PASSWORD     |                                  |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set ADMIN_PASSWORD but not ADMIN_USERNAME
+    When container is started with env
+      | variable           | value                            |
+      | ADMIN_PASSWORD     | GoP@ts6!                         |
+    Then container log should contain Added user 'eapadmin' to file '/opt/eap/standalone/configuration/mgmt-users.properties'
+
+  Scenario: Set NODE_NAME to null
+    When container is started with env
+      | variable           | value                            |
+      | EAP_NODE_NAME      | eap-test-node-name               |
+      | NODE_NAME          |                                  |
+    Then container log should contain jboss.node.name = eap-test-node-name
+
+  Scenario: Test setting DATA_DIR to null
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable    | value         |
+       | APP_DATADIR | configuration |
+       | DATA_DIR    |               |
+    Then s2i build log should contain Copying app data from configuration to /opt/eap/standalone/data
+    And run ls /opt/eap/standalone/data/standalone-openshift.xml in container and check its output for /opt/eap/standalone/data/standalone-openshift.xml
+
+  # https://issues.jboss.org/browse/CLOUD-1168
+  Scenario: Test DATA_DIR with DATA_DIR and APP_DATADIR set, DATA_DIR is not existing
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable    | value                         |
+       | APP_DATADIR | modules/org/postgresql94/main |
+       | DATA_DIR    | /tmp/test                     |
+    Then s2i build log should contain Copying app data from modules/org/postgresql94/main to /tmp/test...
+     And run ls /tmp/test/module.xml in container and check its output for /tmp/test/module.xml
+
+  # https://issues.jboss.org/browse/CLOUD-1168
+  Scenario: Test DATA_DIR with DATA_DIR and APP_DATADIR set, DATA_DIR is existing and not owned by the user
+    Given s2i build https://github.com/jboss-openshift/openshift-examples from helloworld
+       | variable    | value                         |
+       | APP_DATADIR | modules/org/postgresql94/main |
+       | DATA_DIR    | /tmp                          |
+    Then s2i build log should contain Copying app data from modules/org/postgresql94/main to /tmp...
+     And run ls /tmp/module.xml in container and check its output for /tmp/module.xml

--- a/tests/features/LICENSE
+++ b/tests/features/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/features/README.md
+++ b/tests/features/README.md
@@ -1,0 +1,1 @@
+This directory contains CTF tests for JBoss EAP OpenShift container images.

--- a/tests/features/common.feature
+++ b/tests/features/common.feature
@@ -1,0 +1,52 @@
+@wip
+@jboss-eap-7 @jboss-eap-6
+Feature: Openshift common test
+  Scenario: Check jolokia port is available
+    When container is ready
+    Then check that port 8778 is open
+    Then inspect container
+       | path                    | value       |
+       | /Config/ExposedPorts    | 8778/tcp    |
+
+  Scenario: Enable Access Log
+    When container is started with env
+      | variable          | value            |
+      | ENABLE_ACCESS_LOG | true             |
+    Then container log should contain INFO Configuring Access Log Valve.
+
+  Scenario: Test Default Access Log behavior
+    When container is ready
+    Then container log should not contain Configuring Access Log Valve.
+    And container log should contain Access log is disabled, ignoring configuration.
+
+  # CLOUD-1017: Option to enable script debugging
+  Scenario: Check that script debugging (set -x) can be enabled
+    When container is started with env
+       | variable     | value |
+       | SCRIPT_DEBUG | true  |
+    Then container log should contain + echo 'Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed'
+
+  # CLOUD-427: we need to ensure jboss.node.name doesn't go beyond 23 chars
+  Scenario: Check that long node names are truncated to 23 characters
+    When container is started with env
+       | variable  | value                      |
+       | NODE_NAME | abcdefghijklmnopqrstuvwxyz |
+    Then container log should contain jboss.node.name = defghijklmnopqrstuvwxyz
+
+  Scenario: Check that node name is used
+    When container is started with env
+       | variable  | value                      |
+       | NODE_NAME | abcdefghijk                |
+    Then container log should contain jboss.node.name = abcdefghijk
+
+  # https://issues.jboss.org/browse/CLOUD-912
+  Scenario: Check that java binaries are linked properly
+    When container is ready
+    Then run sh -c 'test -L /usr/bin/java && echo "yes" || echo "no"' in container and immediately check its output for yes
+     And run sh -c 'test -L /usr/bin/keytool && echo "yes" || echo "no"' in container and immediately check its output for yes
+     And run sh -c 'test -L /usr/bin/rmid && echo "yes" || echo "no"' in container and immediately check its output for yes
+     And run sh -c 'test -L /usr/bin/javac && echo "yes" || echo "no"' in container and immediately check its output for yes
+     And run sh -c 'test -L /usr/bin/jar && echo "yes" || echo "no"' in container and immediately check its output for yes
+     And run sh -c 'test -L /usr/bin/rmic && echo "yes" || echo "no"' in container and immediately check its output for yes
+     And run sh -c 'test -L /usr/bin/xjc && echo "yes" || echo "no"' in container and immediately check its output for yes
+     And run sh -c 'test -L /usr/bin/wsimport && echo "yes" || echo "no"' in container and immediately check its output for yes

--- a/tests/features/common.feature
+++ b/tests/features/common.feature
@@ -1,4 +1,3 @@
-@wip
 @jboss-eap-7 @jboss-eap-6
 Feature: Openshift common test
   Scenario: Check jolokia port is available

--- a/tests/features/openshift.feature
+++ b/tests/features/openshift.feature
@@ -1,0 +1,30 @@
+@jboss-eap-6 @jboss-eap-7
+Feature: tests for all openshift images
+
+  Scenario: Check that labels are correctly set
+    Given image is built
+    Then the image should contain label com.redhat.component containing value jboss
+    Then the image should contain label com.redhat.component containing value openshift
+
+  Scenario: Check that labels are correctly set
+    Given image is built
+    Then the image should contain label release
+    And the image should contain label version
+    And the image should contain label name
+    And the image should contain label architecture with value x86_64
+    And the image should contain label io.openshift.s2i.scripts-url with value image:///usr/local/s2i
+
+  Scenario: check started as alternative UID
+    # chosen by fair dice roll. guaranteed to be random.
+    When container is started as uid 27558
+    Then container log should contain Running
+     And run id -u in container and check its output contains 27558
+     And all files under /home/jboss are writeable by current user
+     And run whoami in container and immediately check its output for jboss
+
+  Scenario: check started as another alternative UID
+    When container is started as uid 26458
+    Then container log should contain Running
+     And run id -u in container and check its output contains 26458
+     And run whoami in container and immediately check its output for jboss
+


### PR DESCRIPTION
Signed-off-by: Ken Wills <kwills@redhat.com>
https://issues.jboss.org/browse/CLOUD-3003

cct_module change here: https://github.com/jboss-openshift/cct_module/pull/308

This also divides the tests into EAP 6 and EAP 7 hierarchies to allow easier maintenance, and fixes several tests.