### PR TITLE
[CLOUD-2923] - upgrade activemq-rar to Rollup 9 patch

### DIFF
--- a/os-eap-activemq-rar/module.yaml
+++ b/os-eap-activemq-rar/module.yaml
@@ -7,5 +7,5 @@ execute:
   user: '185'
 
 artifacts:
-- url: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630347/activemq-rar-5.11.0.redhat-630347.rar
-  md5: d26da935b1ad5162019d124b23144611
+- url: https://maven.repository.redhat.com/nexus/content/groups/product-ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630356/activemq-rar-5.11.0.redhat-630356.rar
+  md5: f53c5cb09f81456ce183b8b3ebdb7c11


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2923
Signed-off-by: Ken Wills <kwills@redhat.com>

Updated from: https://github.com/jboss-openshift/cct_module/pull/323