### PR TITLE
[CLOUD-2784] Prometheus jmx-exporter configuration

### DIFF
--- a/jboss/container/eap/prometheus/config/6.4/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+++ b/jboss/container/eap/prometheus/config/6.4/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
@@ -39,7 +39,7 @@ rules:
 # Web Metrics
 # Sessions
 - pattern: "jboss.as<deployment=(.+), *subsystem=web><>(active_sessions|max_active_sessions): (.+)"
-  name: web_$2
+  name: jboss_web_$2
   help: Web Session Metrics $2
   value: $3
   valueFactor: 1
@@ -49,7 +49,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=web><>(active_sessions|max_active_sessions): (.+)"
-  name: web_$3
+  name: jboss_web_$3
   help: Web Session Metrics $3
   value: $4
   valueFactor: 1
@@ -59,7 +59,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=web><>(session_avg_alive_time|session_max_alive_time): (.+)"
-  name: web_$2_seconds
+  name: jboss_web_$2_seconds
   help: Web Session Metrics $2
   value: $3
   valueFactor: .001
@@ -69,7 +69,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=web><>(session_avg_alive_time|session_max_alive_time): (.+)"
-  name: web_$3_seconds
+  name: jboss_web_$3_seconds
   help: Web Session Metrics $3
   value: $4
   valueFactor: .001
@@ -79,7 +79,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=web><>(duplicated_session_ids|expired_sessions|rejected_sessions|sessions_created): (.+)"
-  name: web_$2_total
+  name: jboss_web_$2_total
   help: Web Session Metrics $2
   value: $3
   valueFactor: 1
@@ -89,7 +89,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=web><>(duplicated_session_ids|expired_sessions|rejected_sessions|sessions_created): (.+)"
-  name: web_$3_total
+  name: jboss_web_$3_total
   help: Web Session Metrics $3
   value: $4
   valueFactor: 1
@@ -100,7 +100,7 @@ rules:
   type: COUNTER
 # Servlets
 - pattern: "jboss.as<deployment=(.+), *subsystem=web, *servlet=(.+)><>(load_time|max_time|min_time): (.+)"
-  name: web_servlet_$3_seconds
+  name: jboss_web_$3_seconds
   help: Web Servlet Metrics $3
   value: $4
   valueFactor: .001
@@ -111,7 +111,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=web, *servlet=(.+)><>(load_time|max_time|min_time): (.+)"
-  name: web_servlet_$4_seconds
+  name: jboss_web_$4_seconds
   help: Web Servlet Metrics $4
   value: $5
   valueFactor: .001
@@ -122,7 +122,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=web, *servlet=(.+)><>(processing_time): (.+)"
-  name: web_servlet_$3_seconds_total
+  name: jboss_web_$3_seconds_total
   help: Web Servlet Metrics $3
   value: $4
   valueFactor: .001
@@ -133,7 +133,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=web, *servlet=(.+)><>(processing_time): (.+)"
-  name: web_servlet_$4_seconds_total
+  name: jboss_web_$4_seconds_total
   help: Web Servlet Metrics $4
   value: $5
   valueFactor: .001
@@ -144,7 +144,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subsystem=web, *servlet=(.+)><>(request_count): (.+)"
-  name: web_servlet_$3_total
+  name: jboss_web_$3_total
   help: Web Servlet Metrics $3
   value: $4
   valueFactor: 1
@@ -155,7 +155,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=web, *servlet=(.+)><>(request_count): (.+)"
-  name: web_servlet_$4_total
+  name: jboss_web_$4_total
   help: Web Servlet Metrics $4
   value: $5
   valueFactor: 1
@@ -168,150 +168,138 @@ rules:
 
 # EJB
 - pattern: "jboss.as<deployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(peak_concurrent_invocations|pool_available_count|pool_current_size|pool_max_size): (.+)"
-  name: ejb3_$4
+  name: jboss_ejb3_$4
   help: EJB Metrics $4
   value: $5
   valueFactor: 1
   labels:
     deployment: $1
     subdeployment: $1
-    type: $2
-    name: $3
+    $2: $3
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(peak_concurrent_invocations|pool_available_count|pool_current_size|pool_max_size): (.+)"
-  name: ejb3_$5
+  name: jboss_jb3_$5
   help: EJB Metrics $5
   value: $6
   valueFactor: 1
   labels:
     deployment: $1
     subdeployment: $2
-    type: $3
-    name: $4
+    $3: $4
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(invocations|pool_create_count|pool_remove_count): (.+)"
-  name: ejb3_$4_total
+  name: jboss_ejb3_$4_total
   help: EJB Metrics $4
   value: $5
   valueFactor: 1
   labels:
     deployment: $1
     subdeployment: $1
-    type: $2
-    name: $3
+    $3: $4
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(invocations|pool_create_count|pool_remove_count): (.+)"
-  name: ejb3_$5_total
+  name: jboss_ejb3_$5_total
   help: EJB Metrics $5
   value: $6
   valueFactor: 1
   labels:
     deployment: $1
     subdeployment: $2
-    type: $3
-    name: $4
+    $3: $4
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(execution_time|wait_time): (.+)"
-  name: ejb3_$4_seconds_total
+  name: jboss_ejb3_$4_seconds_total
   help: EJB Metrics $4
   value: $5
   valueFactor: .001
   labels:
     deployment: $1
     subdeployment: $1
-    type: $2
-    name: $3
+    $2: $3
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(execution_time|wait_time): (.+)"
-  name: ejb3_$5_seconds_total
+  name: jboss_ejb3_$5_seconds_total
   help: EJB Metrics $5
   value: $6
   valueFactor: .001
   labels:
     deployment: $1
     subdeployment: $2
-    type: $3
-    name: $4
+    $3: $4
   attrNameSnakeCase: true
   type: COUNTER
 
 # Datasources
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=jdbc><>(prepared_statement_cache_current_size): (.+)"
-  name: datasources_$3
+  name: jboss_datasources_jbdc_$3
   help: Datasource JDBC Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=jdbc><>(prepared_statement_cache_access_count|prepared_statement_cache_add_count|prepared_statement_cache_delete_count|prepared_statement_cache_hit_count|prepared_statement_cache_miss_count): (.+)"
-  name: datasources_$3_total
+  name: jboss_datasources_jdbc_$3_total
   help: Datasource JDBC Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(active_count|available_count|in_use_count|max_used_count): (.+)"
-  name: datasources_$3
+  name: jboss_datasources_pool_$3
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(average_blocking_time|average_creation_time|max_creation_time|max_wait_time): (.+)"
-  name: datasources_$3_seconds
+  name: jboss_datasources_pool_$3_seconds
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: .001
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(created_count|destroyed_count|timed_out): (.+)"
-  name: datasources_$3_total
+  name: jboss_datasources_pool_$3_total
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(total_blocking_time|total_creation_time): (.+)"
-  name: datasources_$3_seconds_total
+  name: jboss_datasources_pool_$3_seconds_total
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: .001
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: COUNTER
 
 # Transactions
 - pattern: "jboss.as<subsystem=transactions><>(number_of_inflight_transactions): (.+)"
-  name: transactions_$1
+  name: jboss_transactions_$1
   help: Transactions Metrics $1
   value: $2
   valueFactor: 1
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=transactions><>(number_of_aborted_transactions|number_of_application_rollbacks|number_of_committed_transactions|number_of_heuristics|number_of_nested_transactions|number_of_resource_rollbacks|number_of_timed_out_transactions|number_of_transactions): (.+)"
-  name: transactions_$1_total
+  name: jboss_transactions_$1_total
   help: Transactions Metrics $1
   value: $2
   valueFactor: 1
@@ -320,24 +308,22 @@ rules:
 
 # JMS
 - pattern: "jboss.as<subsystem=messaging, *hornetq-server=(.+), *(.+)=(.+)><>(consumer_count|delivering_count|durable_message_count|durable_subscription_count|message_count|non_durable_message_count|non_durable_subscription_count|scheduled_count|subscription_count): (.+)"
-  name: messaging_$4
+  name: jboss_messaging_$4
   help: Messaging JMS Queue Metrics $4
   value: $5
   valueFactor: 1
   labels:
     server: $1
-    type: $2
-    name: $3
+    $2: $3
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=messaging, *hornetq-server=(.+), *(.+)=(.+)><>(messages_added): (.+)"
-  name: messaging_$4_total
+  name: jboss_messaging_$4_total
   help: Messaging JMS Queue Metrics $4
   value: $5
   valueFactor: 1
   labels:
     server: $1
-    type: $2
-    name: $3
+    $2: $3
   attrNameSnakeCase: true
   type: COUNTER

--- a/jboss/container/eap/prometheus/config/7.1/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
+++ b/jboss/container/eap/prometheus/config/7.1/artifacts/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml
@@ -31,6 +31,7 @@ whitelistObjectNames:
 - "jboss.as:subsystem=messaging-activemq,server=*,jms-queue=*"
 - "jboss.as:subsystem=messaging-activemq,server=*,jms-topic=*"
 - "jboss.as:subsystem=transactions"
+- "jboss.as:subsystem=undertow,server=*,http-listener=*"
 blacklistObjectNames:
 # handled by agent's default exporter
 - "java.lang:*"
@@ -39,7 +40,7 @@ rules:
 # Undertow Metrics
 # Sessions
 - pattern: "jboss.as<deployment=(.+), *subsystem=undertow><>(active_sessions|max_active_sessions): (.+)"
-  name: undertow_$2
+  name: jboss_undertow_$2
   help: Undertow Session Metrics $2
   value: $3
   valueFactor: 1
@@ -49,7 +50,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=undertow><>(active_sessions|max_active_sessions): (.+)"
-  name: undertow_$3
+  name: jboss_undertow_$3
   help: Undertow Session Metrics $3
   value: $4
   valueFactor: 1
@@ -59,7 +60,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=undertow><>(session_avg_alive_time|session_max_alive_time): (.+)"
-  name: undertow_$2_seconds
+  name: jboss_undertow_$2_seconds
   help: Undertow Session Metrics $2
   value: $3
   valueFactor: .001
@@ -69,7 +70,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=undertow><>(session_avg_alive_time|session_max_alive_time): (.+)"
-  name: undertow_$3_seconds
+  name: jboss_undertow_$3_seconds
   help: Undertow Session Metrics $3
   value: $4
   valueFactor: .001
@@ -79,7 +80,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=undertow><>(expired_sessions|rejected_sessions|sessions_created): (.+)"
-  name: undertow_$2_total
+  name: jboss_undertow_$2_total
   help: Undertow Session Metrics $2
   value: $3
   valueFactor: 1
@@ -89,7 +90,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=undertow><>(expired_sessions|rejected_sessions|sessions_created): (.+)"
-  name: undertow_$3_total
+  name: jboss_undertow_$3_total
   help: Undertow Session Metrics $3
   value: $4
   valueFactor: 1
@@ -100,7 +101,7 @@ rules:
   type: COUNTER
 # Servlets
 - pattern: "jboss.as<deployment=(.+), *subsystem=undertow, *servlet=(.+)><>(max_request_time|min_request_time): (.+)"
-  name: undertow_servlet_$3_seconds
+  name: jboss_undertow_$3_seconds
   help: Undertow Servlet Metrics $3
   value: $4
   valueFactor: .001
@@ -111,7 +112,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=undertow, *servlet=(.+)><>(max_request_time|min_request_time): (.+)"
-  name: undertow_servlet_$4_seconds
+  name: jboss_undertow_$4_seconds
   help: Undertow Servlet Metrics $4
   value: $5
   valueFactor: .001
@@ -122,7 +123,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=undertow, *servlet=(.+)><>(total_request_time): (.+)"
-  name: undertow_servlet_$3_seconds_total
+  name: jboss_undertow_$3_seconds_total
   help: Undertow Servlet Metrics $3
   value: $4
   valueFactor: .001
@@ -133,7 +134,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=undertow, *servlet=(.+)><>(total_request_time): (.+)"
-  name: undertow_servlet_$4_seconds_total
+  name: jboss_undertow_$4_seconds_total
   help: Undertow Servlet Metrics $4
   value: $5
   valueFactor: .001
@@ -144,7 +145,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subsystem=undertow, *servlet=(.+)><>(request_count): (.+)"
-  name: undertow_servlet_$3_total
+  name: jboss_undertow_$3_total
   help: Undertow Servlet Metrics $3
   value: $4
   valueFactor: 1
@@ -155,7 +156,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=undertow, *servlet=(.+)><>(request_count): (.+)"
-  name: undertow_servlet_$4_total
+  name: jboss_undertow_$4_total
   help: Undertow Servlet Metrics $4
   value: $5
   valueFactor: 1
@@ -165,10 +166,20 @@ rules:
     servlet: $3
   attrNameSnakeCase: true
   type: COUNTER
-
+# Undertow Subsystem HTTP Listeners
+- pattern: "jboss.as<subsystem=undertow, *server=(.+), *http-listener=(.+)><>(request_count): (.+)"
+  name: jboss_undertow_$3_total
+  help: Undertow Listener Metrics $3
+  value: $4
+  valueFactor: 1
+  labels:
+     server: $1
+     http-listener: $2
+  attrNameSnakeCase: true
+  type: COUNTER
 # EJB
 - pattern: "jboss.as<deployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(peak_concurrent_invocations|pool_available_count|pool_current_size|pool_max_size): (.+)"
-  name: ejb3_$4
+  name: jboss_ejb3_$4
   help: EJB Metrics $4
   value: $5
   valueFactor: 1
@@ -180,7 +191,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(peak_concurrent_invocations|pool_available_count|pool_current_size|pool_max_size): (.+)"
-  name: ejb3_$5
+  name: jboss_ejb3_$5
   help: EJB Metrics $5
   value: $6
   valueFactor: 1
@@ -192,7 +203,7 @@ rules:
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<deployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(invocations|pool_create_count|pool_remove_count): (.+)"
-  name: ejb3_$4_total
+  name: jboss_ejb3_$4_total
   help: EJB Metrics $4
   value: $5
   valueFactor: 1
@@ -204,7 +215,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(invocations|pool_create_count|pool_remove_count): (.+)"
-  name: ejb3_$5_total
+  name: jboss_ejb3_$5_total
   help: EJB Metrics $5
   value: $6
   valueFactor: 1
@@ -216,7 +227,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(execution_time|wait_time): (.+)"
-  name: ejb3_$4_seconds_total
+  name: jboss_ejb3_$4_seconds_total
   help: EJB Metrics $4
   value: $5
   valueFactor: .001
@@ -228,7 +239,7 @@ rules:
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<deployment=(.+), *subdeployment=(.+), *subsystem=ejb3, *(.+)=(.+)><>(execution_time|wait_time): (.+)"
-  name: ejb3_$5_seconds_total
+  name: jboss_ejb3_$5_seconds_total
   help: EJB Metrics $5
   value: $6
   valueFactor: .001
@@ -242,76 +253,70 @@ rules:
 
 # Datasources
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=jdbc><>(prepared_statement_cache_current_size): (.+)"
-  name: datasources_$3
+  name: jboss_datasources_jdbc_$3
   help: Datasource JDBC Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=jdbc><>(prepared_statement_cache_access_count|prepared_statement_cache_add_count|prepared_statement_cache_delete_count|prepared_statement_cache_hit_count|prepared_statement_cache_miss_count): (.+)"
-  name: datasources_$3_total
+  name: jboss_datasources_jdbc_$3_total
   help: Datasource JDBC Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(active_count|available_count|in_use_count|max_used_count): (.+)"
-  name: datasources_$3
+  name: jboss_datasources_pool_$3
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+      $1: $2
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(average_blocking_time|average_creation_time|average_get_time|max_creation_time|max_get_time|max_wait_time): (.+)"
-  name: datasources_$3_seconds
+  name: jboss_datasources_pool_$3_seconds
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: .001
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(blocking_failure_count|created_count|destroyed_count|idle_count|timed_out|wait_count): (.+)"
-  name: datasources_$3_total
+  name: jboss_datasources_pool_$3_total
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: 1
   labels:
-    type: $1
-    name: $2
+      $1: $2
   attrNameSnakeCase: true
   type: COUNTER
 - pattern: "jboss.as<subsystem=datasources, *(data-source|xa-data-source)=(.+), *statistics=pool><>(total_blocking_time|total_creation_time|total_get_time): (.+)"
-  name: datasources_$3_seconds_total
+  name: jboss_datasources_pool_$3_seconds_total
   help: Datasource Pool Metrics $3
   value: $4
   valueFactor: .001
   labels:
-    type: $1
-    name: $2
+    $1: $2
   attrNameSnakeCase: true
   type: COUNTER
 
 # Transactions
 - pattern: "jboss.as<subsystem=transactions><>(number_of_inflight_transactions): (.+)"
-  name: transactions_$1
+  name: jboss_transactions_$1
   help: Transactions Metrics $1
   value: $2
   valueFactor: 1
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=transactions><>(number_of_aborted_transactions|number_of_application_rollbacks|number_of_committed_transactions|number_of_heuristics|number_of_nested_transactions|number_of_resource_rollbacks|number_of_timed_out_transactions|number_of_transactions): (.+)"
-  name: transactions_$1_total
+  name: jboss_transactions_$1_total
   help: Transactions Metrics $1
   value: $2
   valueFactor: 1
@@ -320,24 +325,22 @@ rules:
 
 # JMS
 - pattern: "jboss.as<subsystem=messaging-activemq, *server=(.+), *(.+)=(.+)><>(consumer_count|delivering_count|durable_message_count|durable_subscription_count|message_count|non_durable_message_count|non_durable_subscription_count|scheduled_count|subscription_count): (.+)"
-  name: messaging_activemq_$4
+  name: jboss_messaging_activemq_$4
   help: Messaging JMS Queue Metrics $4
   value: $5
   valueFactor: 1
   labels:
     server: $1
-    type: $2
-    name: $3
+    $2: $3
   attrNameSnakeCase: true
   type: GAUGE
 - pattern: "jboss.as<subsystem=messaging-activemq, *server=(.+), *(.+)=(.+)><>(messages_added): (.+)"
-  name: messaging_activemq_$4_total
+  name: jboss_messaging_activemq_$4_total
   help: Messaging JMS Queue Metrics $4
   value: $5
   valueFactor: 1
   labels:
     server: $1
-    type: $2
-    name: $3
+    $2: $3
   attrNameSnakeCase: true
   type: COUNTER


### PR DESCRIPTION
Update the jmx-exporter configuration for both EAP 6.4 and 7.1 agents so
that the metric names and labels follows the same convention that the
metrics that will be exposed by a subsystem in next EAP releases:

* add `jboss_` prefix to all metrics
* renamed `web_servlet_xxx` and `undertow_servlet_xxx` to
  `jboss_web_xxx` and `jboww_undertow_xxx` (as the `servlet is already
  mentioned in the labels`
* remove labels of type `type: $2, name:$3` and replace them by a single
  label `$2: $3` to be consistent with other labels (that maps to the
  resource path address.
  As an example, metrics for datasource:
  * before: `type: data-source, name=ExampleDS`
  * now: `data_source: ExampleDS`
* renamed datasources metrics to either `jboss_datasources_jdbc` or
  `jboss_datasources_pool` depending on the origin of the statistics.

These changes ensure that the metric names and labels can be
consistently computed from the resource metadata and its address without
specific treatment depending on the resources.

JIRA: https://issues.jboss.org/browse/CLOUD-2784