### PR TITLE
Update CR5 modules to include missing activemq RA configure script and increment module version to 1.1 to avoid clash with legacy cct_module version

### DIFF
--- a/os-eap-activemq-rar/configure.sh
+++ b/os-eap-activemq-rar/configure.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Add Active-MQ rar
+set -e
+
+SOURCES_DIR=/tmp/artifacts
+
+cp -p ${SOURCES_DIR}/activemq-rar-5.11.0.redhat-*.rar ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar
+
+chown jboss:root ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar
+chmod g+rwX ${JBOSS_HOME}/standalone/deployments/activemq-rar.rar

--- a/os-eap-activemq-rar/module.yaml
+++ b/os-eap-activemq-rar/module.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 name: os-eap-activemq-rar
-version: '1.0'
+version: '1.1'
 description: Legacy os-eap-activemq-rar script package.
 execute:
 - script: configure.sh


### PR DESCRIPTION
Signed-off-by: Ken WIlls <kwills@redhat.com>