### PR TITLE
CLOUD-3135 - allow behave tests to override node name

### DIFF
--- a/os-eap-txnrecovery/bash/added/partitionPV.sh
+++ b/os-eap-txnrecovery/bash/added/partitionPV.sh
@@ -39,6 +39,9 @@ function arrContains() {
 function init_pod_name() {
   # when POD_NAME is non-zero length using that given name
 
+  # if the user specifies NODE_NAME or JBOSS_NODE_NAME - this is ONLY intended to be used by tests.
+  [ -n "${NODE_NAME}" ] && POD_NAME="${NODE_NAME}"
+  [ -n "${JBOSS_NODE_NAME}" ] && POD_NAME="${JBOSS_NODE_NAME}"
   # docker sets up container_uuid
   [ -z "${POD_NAME}" ] && POD_NAME="${container_uuid}"
   # openshift sets up the node id as host name


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3135
Signed-off-by: Ken Wills <kwills@redhat.com>