### PR TITLE
[CLOUD-3138] Replace 'OPENSHIFT_KUBE_PING_NAMESPACE' with 'JGROUPS_PING_PROTOCOL'

### DIFF
--- a/tests/features/6/basic.feature
+++ b/tests/features/6/basic.feature
@@ -75,7 +75,7 @@ Feature: Openshift EAP common tests (EAP and EAP derived images)
        | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
        | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
        | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                     |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                     |
        | JGROUPS_CLUSTER_PASSWORD                     | asdasdasdasdgfd                        |
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='SYM_ENCRYPT']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /etc/jgroups-encrypt-secret-volume/keystore.jks on XPath //*[local-name()='protocol'][@type='SYM_ENCRYPT']/*[local-name()='property'][@name='keystore_name']

--- a/tests/features/7/basic.feature
+++ b/tests/features/7/basic.feature
@@ -88,7 +88,7 @@ Feature: Common EAP tests
        | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
        | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
        | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                     |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                     |
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='auth-protocol'][@type='AUTH']
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
@@ -144,7 +144,7 @@ Feature: Common EAP tests
     When container is started with env
        | variable                                     | value                                   |
        | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                      |
     Then container log should contain WARN JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT requires JGROUPS_CLUSTER_PASSWORD to be set and not empty, the communication within the cluster WILL NOT be encrypted.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
@@ -153,7 +153,7 @@ Feature: Common EAP tests
        | variable                                     | value                                   |
        | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
        | JGROUPS_ENCRYPT_SECRET                       | jdg_jgroups_encrypt_secret              |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                      |
     Then container log should contain WARN The specified JGroups configuration properties (JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE_DIR JGROUPS_ENCRYPT_KEYSTORE) will be ignored when using JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT. Only JGROUPS_CLUSTER_PASSWORD is used.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
@@ -162,7 +162,7 @@ Feature: Common EAP tests
        | variable                                     | value                                   |
        | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
        | JGROUPS_ENCRYPT_NAME                         | jboss                                   |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                      |
     Then container log should contain WARN The specified JGroups configuration properties (JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE_DIR JGROUPS_ENCRYPT_KEYSTORE) will be ignored when using JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT. Only JGROUPS_CLUSTER_PASSWORD is used.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
@@ -171,7 +171,7 @@ Feature: Common EAP tests
        | variable                                     | value                                   |
        | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
        | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                          |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                      |
     Then container log should contain WARN The specified JGroups configuration properties (JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE_DIR JGROUPS_ENCRYPT_KEYSTORE) will be ignored when using JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT. Only JGROUPS_CLUSTER_PASSWORD is used.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
@@ -180,7 +180,7 @@ Feature: Common EAP tests
        | variable                                     | value                                   |
        | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
        | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume      |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                      |
     Then container log should contain WARN The specified JGroups configuration properties (JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE_DIR JGROUPS_ENCRYPT_KEYSTORE) will be ignored when using JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT. Only JGROUPS_CLUSTER_PASSWORD is used.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
@@ -189,7 +189,7 @@ Feature: Common EAP tests
        | variable                                     | value                                   |
        | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT                            |
        | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                            |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                      |
     Then container log should contain WARN The specified JGroups configuration properties (JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE_DIR JGROUPS_ENCRYPT_KEYSTORE) will be ignored when using JGROUPS_ENCRYPT_PROTOCOL=ASYM_ENCRYPT. Only JGROUPS_CLUSTER_PASSWORD is used.
 
   Scenario: No duplicate module jars

--- a/tests/features/7/jgroups.feature
+++ b/tests/features/7/jgroups.feature
@@ -6,7 +6,7 @@ Feature: Openshift EAP jgroups
     When container is started with env
        | variable                 | value    |
        | JGROUPS_CLUSTER_PASSWORD | asdfasdf |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL               | openshift.DNS_PING                      |
 
     Then container log should contain WFLYSRV0025:
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='auth-protocol'][@type='AUTH']
@@ -18,7 +18,7 @@ Feature: Openshift EAP jgroups
        | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
        | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
        | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                     |
     Then container log should contain WFLYSRV0025:
      And available container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
 
@@ -29,6 +29,6 @@ Feature: Openshift EAP jgroups
        | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
        | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
        | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
-       | OPENSHIFT_KUBE_PING_NAMESPACE                | openshift.DNS_PING                      |
+       | JGROUPS_PING_PROTOCOL                        | openshift.DNS_PING                     |
     Then container log should contain WFLYSRV0025:
      And available container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.


### PR DESCRIPTION
in selected JGroups CTF tests (where appropriate)

Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>

P.S. See the result of PR change testing in the next comment