### PR TITLE
[CLOUD-3164] URL to check view pods permission is not correct

### DIFF
--- a/jboss-eap-config-jgroups/added/launch/ha.sh
+++ b/jboss-eap-config-jgroups/added/launch/ha.sh
@@ -39,7 +39,7 @@ check_view_pods_permission() {
 
         pods_url="https://${service_host}:${service_port}/api/${api_version}/namespaces/${namespace}/pods"
         if [ -n "${labels}" ]; then
-            pods_labels="labels=${labels}"
+            pods_labels="labelSelector=${labels}"
         else
             pods_labels=""
         fi


### PR DESCRIPTION
Use `labelSelector` instead of `labels` to query the pods with the
required labels (as documented in
https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#list-and-watch-filtering)

JIRA: https://issues.jboss.org/browse/CLOUD-3164