### PR TITLE
[CLOUD-3208] - [7.2.x] SSO_SECRET parameter should be required if configuring RH-SSO integration

### DIFF
--- a/os-eap-sso/added/keycloak.sh
+++ b/os-eap-sso/added/keycloak.sh
@@ -420,6 +420,10 @@ function configure_client() {
   client_config="${client_config},\"publicClient\":\"false\",\"secret\":\"${SSO_SECRET}\""
   client_config="${client_config}}"
 
+  if [ -z "$SSO_SECRET" ]; then
+    log_warning "ERROR: SSO_SECRET not set. Make sure to generate a secret in the SSO/Keycloak client '$module_name' configuration and then set the SSO_SECRET variable." 
+  fi
+
   result=`$CURL -H "Content-Type: application/json" -H "Authorization: Bearer ${token}" -X POST -d "${client_config}" ${sso_service}/admin/realms/${SSO_REALM}/clients`
 
   if [ -n "$result" ]; then


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3208
Upstream PR: https://github.com/jboss-container-images/jboss-eap-modules/pull/86
Signed-off-by: Ken Wills <kwills@redhat.com>