### PR TITLE
[CLOUD-3210] 7.2.x-openjdk11] Update ping modules to 1.2.5

### DIFF
--- a/os-eap64-ping/configure.sh
+++ b/os-eap64-ping/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
-VERSION="1.2.3.Final-redhat-1"
+VERSION="1.2.5.Final-redhat-1"
 
 DEST=${JBOSS_HOME}/modules/system/layers/openshift/org/openshift/ping/main
 mkdir -p ${DEST}

--- a/os-eap64-ping/module.yaml
+++ b/os-eap64-ping/module.yaml
@@ -26,14 +26,14 @@ envs:
 
 artifacts:
 - name: openshift-ping-common
-  target: openshift-ping-common-1.2.3.Final-redhat-1.jar
-  md5: 2722e17d2b230184572b9e6539195c4d
+  target: openshift-ping-common-1.2.5.Final-redhat-1.jar
+  md5: 12b4f1e021e8d5b8ba199ee60faca008
 - name: openshift-ping-dns
-  target: openshift-ping-dns-1.2.3.Final-redhat-1.jar
-  md5: a87fd933f56ef7619d9ca676e7a3d208
+  target: openshift-ping-dns-1.2.5.Final-redhat-1.jar
+  md5: df89212d776cdd3c64bc578c60173788
 - name: openshift-ping-kube
-  target: openshift-ping-kube-1.2.3.Final-redhat-1.jar
-  md5: 3c8e75aad63eeb5379530d1ee76a4122
+  target: openshift-ping-kube-1.2.5.Final-redhat-1.jar
+  md5: 1cbb306ba252a71ee2c4309910b459fc
 - name: oauth
   target: oauth-20100527.jar
   md5: 91c7c70579f95b7ddee95b2143a49b41

--- a/os-eap7-ping/configure.sh
+++ b/os-eap7-ping/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
-VERSION="1.2.3.Final-redhat-1"
+VERSION="1.2.5.Final-redhat-1"
 
 DEST=${JBOSS_HOME}/modules/system/layers/openshift/org/openshift/ping/main
 mkdir -p ${DEST}

--- a/os-eap7-ping/module.yaml
+++ b/os-eap7-ping/module.yaml
@@ -26,14 +26,14 @@ envs:
 
 artifacts:
 - name: openshift-ping-common
-  target: openshift-ping-common-1.2.3.Final-redhat-1.jar
-  md5: 2722e17d2b230184572b9e6539195c4d
+  target: openshift-ping-common-1.2.5.Final-redhat-1.jar
+  md5: 12b4f1e021e8d5b8ba199ee60faca008
 - name: openshift-ping-dns
-  target: openshift-ping-dns-1.2.3.Final-redhat-1.jar
-  md5: a87fd933f56ef7619d9ca676e7a3d208
+  target: openshift-ping-dns-1.2.5.Final-redhat-1.jar
+  md5: df89212d776cdd3c64bc578c60173788
 - name: openshift-ping-kube
-  target: openshift-ping-kube-1.2.3.Final-redhat-1.jar
-  md5: 3c8e75aad63eeb5379530d1ee76a4122
+  target: openshift-ping-kube-1.2.5.Final-redhat-1.jar
+  md5: 1cbb306ba252a71ee2c4309910b459fc
 - name: oauth
   target: oauth-20100527.jar
   md5: 91c7c70579f95b7ddee95b2143a49b41


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3210
Upstream PR: https://github.com/jboss-container-images/jboss-eap-modules/pull/80
Signed-off-by: Ken Wills <kwills@redhat.com>