### PR TITLE
CLOUD-3198 Datasource generation should escape ampersand

### DIFF
--- a/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -180,7 +180,10 @@ function generate_datasource_common() {
   local service_name="${11}"
   local jta="${12}"
   local validate="${13}"
-  local url="${14}"
+  # CLOUD-3198 Since Sed replaces '&' with a full match, we need to escape it.
+  local url="${14//&/\\&}"
+  # CLOUD-3198 In addition to that, we also need to escape ';'
+  url="${url//;/\\;}"
 
   if [ -n "$driver" ]; then
     ds=$(generate_external_datasource)

--- a/os-eap-launch/added/launch/datasource-common.sh
+++ b/os-eap-launch/added/launch/datasource-common.sh
@@ -188,7 +188,10 @@ function generate_datasource_common() {
   local service_name="${11}"
   local jta="${12}"
   local validate="${13}"
-  local url="${14}"
+  # CLOUD-3198 Since Sed replaces '&' with a full match, we need to escape it.
+  local url="${14//&/\\&}"
+  # CLOUD-3198 In addition to that, we also need to escape ';'
+  url="${url//;/\\;}"
 
   if [ -n "$driver" ]; then
     ds=$(generate_external_datasource)


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3198

This Pull Request fixes the ampersand in URL parsing problem. the problem might be reproduced by using `DB_URL=jdbc:postgresql://172.17.0.2:5432/rhsso&ssl=true`. Without this Pull Request, the connection url would be trimmed to `jdbc:postgresql://172.17.0.2:5432/rhsso` (without `&ssl=true`). 

Dear EAP Team - I'm not sure where would you like to test this feature out. Perhaps it would be best if you could add one commit on top of mine, and implement proper test (in any place you'd like it to be).

@iankko @luck3y  Please take a look at this PR once you have a chance.