### PR TITLE
[CLOUD-3235] - Fixing missed VERSION variable value

### DIFF
--- a/os-eap64-ping/configure.sh
+++ b/os-eap64-ping/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
-VERSION="1.2.5.Final-redhat-1"
+VERSION="1.2.6.Final-redhat-1"
 
 DEST=${JBOSS_HOME}/modules/system/layers/openshift/org/openshift/ping/main
 mkdir -p ${DEST}

--- a/os-eap7-ping/configure.sh
+++ b/os-eap7-ping/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
-VERSION="1.2.5.Final-redhat-1"
+VERSION="1.2.6.Final-redhat-1"
 
 DEST=${JBOSS_HOME}/modules/system/layers/openshift/org/openshift/ping/main
 mkdir -p ${DEST}


### PR DESCRIPTION
Should be reopened:
https://issues.jboss.org/browse/CLOUD-3235

There's a VERSION var that should be updated as well. The images builds are broken because of this.

Signed-off-by: Ricardo Zanini <zanini@redhat.com>