### PR TITLE
[CLOUD-3236] - Update ping modules to fix certificate issue in OCP 4.1

### DIFF
--- a/os-eap64-ping/configure.sh
+++ b/os-eap64-ping/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
-VERSION="1.2.5.Final-redhat-1"
+VERSION="1.2.6.Final-redhat-1"
 
 DEST=${JBOSS_HOME}/modules/system/layers/openshift/org/openshift/ping/main
 mkdir -p ${DEST}

--- a/os-eap64-ping/module.yaml
+++ b/os-eap64-ping/module.yaml
@@ -26,14 +26,14 @@ envs:
 
 artifacts:
 - name: openshift-ping-common
-  target: openshift-ping-common-1.2.5.Final-redhat-1.jar
-  md5: 12b4f1e021e8d5b8ba199ee60faca008
+  target: openshift-ping-common-1.2.6.Final-redhat-1.jar
+  md5: 94f0bd57b1990b556890d99290bdd847
 - name: openshift-ping-dns
-  target: openshift-ping-dns-1.2.5.Final-redhat-1.jar
-  md5: df89212d776cdd3c64bc578c60173788
+  target: openshift-ping-dns-1.2.6.Final-redhat-1.jar
+  md5: 59925c951d904b7734c2d10dc41a6515
 - name: openshift-ping-kube
-  target: openshift-ping-kube-1.2.5.Final-redhat-1.jar
-  md5: 1cbb306ba252a71ee2c4309910b459fc
+  target: openshift-ping-kube-1.2.6.Final-redhat-1.jar
+  md5: 0e4dc6aa494395dddf0f645b38ef4e54
 - name: oauth
   target: oauth-20100527.jar
   md5: 91c7c70579f95b7ddee95b2143a49b41

--- a/os-eap7-ping/configure.sh
+++ b/os-eap7-ping/configure.sh
@@ -5,7 +5,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
-VERSION="1.2.5.Final-redhat-1"
+VERSION="1.2.6.Final-redhat-1"
 
 DEST=${JBOSS_HOME}/modules/system/layers/openshift/org/openshift/ping/main
 mkdir -p ${DEST}

--- a/os-eap7-ping/module.yaml
+++ b/os-eap7-ping/module.yaml
@@ -26,14 +26,14 @@ envs:
 
 artifacts:
 - name: openshift-ping-common
-  target: openshift-ping-common-1.2.5.Final-redhat-1.jar
-  md5: 12b4f1e021e8d5b8ba199ee60faca008
+  target: openshift-ping-common-1.2.6.Final-redhat-1.jar
+  md5: 94f0bd57b1990b556890d99290bdd847
 - name: openshift-ping-dns
-  target: openshift-ping-dns-1.2.5.Final-redhat-1.jar
-  md5: df89212d776cdd3c64bc578c60173788
+  target: openshift-ping-dns-1.2.6.Final-redhat-1.jar
+  md5: 59925c951d904b7734c2d10dc41a6515
 - name: openshift-ping-kube
-  target: openshift-ping-kube-1.2.5.Final-redhat-1.jar
-  md5: 1cbb306ba252a71ee2c4309910b459fc
+  target: openshift-ping-kube-1.2.6.Final-redhat-1.jar
+  md5: 0e4dc6aa494395dddf0f645b38ef4e54
 - name: oauth
   target: oauth-20100527.jar
   md5: 91c7c70579f95b7ddee95b2143a49b41


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3236
Upstream PR: https://github.com/jboss-container-images/jboss-eap-modules/pull/103/ https://github.com/jboss-container-images/jboss-eap-modules/pull/105
Signed-off-by: Roberto Oliveira rguimara@redhat.com