### PR TITLE
CLOUD-3256 - Allow kubernetes to control probe retries; avoid probes taking longer than kubernetes timeout settings

### DIFF
--- a/os-eap-probes/1.0/added/livenessProbe.sh
+++ b/os-eap-probes/1.0/added/livenessProbe.sh
@@ -11,37 +11,22 @@ OUTPUT=/tmp/liveness-output
 ERROR=/tmp/liveness-error
 LOG=/tmp/liveness-log
 
-# liveness failure before management interface is up will cause the probe to fail
-COUNT=30
-SLEEP=5
 DEBUG_SCRIPT=false
 PROBE_IMPL="probe.eap.dmr.EapProbe probe.eap.dmr.HealthCheckProbe"
 
 if [ $# -gt 0 ] ; then
-    COUNT=$1
+    DEBUG_SCRIPT=$1
 fi
 
 if [ $# -gt 1 ] ; then
-    SLEEP=$2
+    PROBE_IMPL=$2
 fi
-
-if [ $# -gt 2 ] ; then
-    DEBUG_SCRIPT=$3
-fi
-
-if [ $# -gt 3 ] ; then
-    PROBE_IMPL=$4
-fi
-
-# Sleep for 5 seconds to avoid launching readiness and liveness probes
-# at the same time
-sleep 5
 
 if [ "$DEBUG_SCRIPT" = "true" ]; then
     DEBUG_OPTIONS="--debug --logfile $LOG --loglevel DEBUG"
 fi
 
-if python $JBOSS_HOME/bin/probes/runner.py -c READY -c NOT_READY --maxruns $COUNT --sleep $SLEEP $DEBUG_OPTIONS $PROBE_IMPL; then
+if python $JBOSS_HOME/bin/probes/runner.py -c READY -c NOT_READY $DEBUG_OPTIONS $PROBE_IMPL; then
     exit 0
 fi
 

--- a/os-eap-probes/1.0/added/probes/probe/dmr.py
+++ b/os-eap-probes/1.0/added/probes/probe/dmr.py
@@ -94,11 +94,11 @@ class DmrProbe(BatchingProbe):
             response because one of the test steps failed, in which case we pass the
             response to the tests to let them decide how to handle things
             """
-            self.failUnusableResponse(response)
+            self.failUnusableResponse(response, request, url)
 
         return response.json(object_pairs_hook = OrderedDict)
 
-    def failUnusableResponse(self, response):
+    def failUnusableResponse(self, response, request, url):
         respDict = None
         try:
             respDict = response.json(object_pairs_hook = OrderedDict)

--- a/os-eap-probes/1.0/added/probes/runner.py
+++ b/os-eap-probes/1.0/added/probes/runner.py
@@ -61,8 +61,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description = "Executes the specified probes returning cleanly if probe status matches desired status")
     parser.add_argument("-c", "--check", required = True, type = toStatus, action = "append", help = "The acceptable probe statuses, may be: READY, NOT_READY.")
     parser.add_argument("-d", "--debug", action = "store_true", help = "Enable debugging")
-    parser.add_argument("-r", "--maxruns", default = 1, type = int, help = "Number of runs to try without success before exiting.")
-    parser.add_argument("-s", "--sleep", default = 1, type = int, help = "Number of seconds to sleep between runs.")
     parser.add_argument("--logfile", help = "Log file.")
     parser.add_argument("--loglevel", default = "CRITICAL", choices = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], help = "Log level.")
     parser.add_argument("probes", nargs = argparse.REMAINDER, help = "The probes to execute.")
@@ -87,35 +85,25 @@ if __name__ == "__main__":
         probeModule = importlib.import_module(probe.rsplit(".", 1)[0])
         probeClass = getattr(probeModule, probe.rsplit(".", 1)[1])
         runner.addProbe(probeClass())
-    
-    maxruns = args.maxruns
+
     okStatus = set(args.check)
     
     logger.info("Probes will fail for the following states: [%s]", ", ".join(str(status) for status in set(Status) - okStatus))
 
     probeStatus = set()
     output = {}
-    while True:
-        maxruns -= 1
-        logger.info("Running probes")
-        (probeStatus, output) = runner.executeProbes()
-        if okStatus >= probeStatus:
-            logger.info("Probes succeeded")
-            if args.debug:
-                print(json.dumps(output, indent=4, separators=(',', ': ')))
-            exit(0)
+    logger.info("Running probes")
+    (probeStatus, output) = runner.executeProbes()
+    if okStatus >= probeStatus:
+        logger.info("Probes succeeded")
+        if args.debug:
+            print(json.dumps(output, indent=4, separators=(',', ': ')))
+        exit(0)
         if Status.HARD_FAILURE in probeStatus:
-            logger.error("Probes detected HARD_FAILURE.  Exiting retry loop.")
-            break
-        if maxruns > 0:
-            logger.error("Probes failed.  Retries remaining: %s.", maxruns)
-            logger.info("Retrying probes in %ss", args.sleep)
-            time.sleep(args.sleep)
-        else:
-            break
+            logger.error("Probes detected HARD_FAILURE.")
 
     # we didn't succeed
-    logger.error("Probe failure.  Probes did not succeed after %s attempts.", args.maxruns - maxruns)
+    logger.error("Probe failure.  Probes did not succeed")
     # print so the output is available to users in the OpenShift event log
     print(json.dumps(output, indent=4, separators=(',', ': ')))
     exit(1)

--- a/os-eap-probes/1.0/added/readinessProbe.sh
+++ b/os-eap-probes/1.0/added/readinessProbe.sh
@@ -6,32 +6,22 @@ OUTPUT=/tmp/readiness-output
 ERROR=/tmp/readiness-error
 LOG=/tmp/readiness-log
 
-COUNT=30
-SLEEP=5
 DEBUG=${SCRIPT_DEBUG:-false}
 PROBE_IMPL="probe.eap.dmr.EapProbe probe.eap.dmr.HealthCheckProbe"
 
 if [ $# -gt 0 ] ; then
-    COUNT=$1
+    DEBUG=$1
 fi
 
 if [ $# -gt 1 ] ; then
-    SLEEP=$2
-fi
-
-if [ $# -gt 2 ] ; then
-    DEBUG=$3
-fi
-
-if [ $# -gt 3 ] ; then
-    PROBE_IMPL=$4
+    PROBE_IMPL=$2
 fi
 
 if [ "$DEBUG" = "true" ]; then
     DEBUG_OPTIONS="--debug --logfile $LOG --loglevel DEBUG"
 fi
 
-if python $JBOSS_HOME/bin/probes/runner.py -c READY --maxruns $COUNT --sleep $SLEEP $DEBUG_OPTIONS $PROBE_IMPL; then
+if python $JBOSS_HOME/bin/probes/runner.py -c READY $DEBUG_OPTIONS $PROBE_IMPL; then
     exit 0
 fi
 exit 1

--- a/os-eap-probes/2.0/added/livenessProbe.sh
+++ b/os-eap-probes/2.0/added/livenessProbe.sh
@@ -11,37 +11,22 @@ OUTPUT=/tmp/liveness-output
 ERROR=/tmp/liveness-error
 LOG=/tmp/liveness-log
 
-# liveness failure before management interface is up will cause the probe to fail
-COUNT=30
-SLEEP=5
 DEBUG_SCRIPT=false
 PROBE_IMPL="probe.eap.dmr.EapProbe probe.eap.dmr.HealthCheckProbe"
 
 if [ $# -gt 0 ] ; then
-    COUNT=$1
+    DEBUG_SCRIPT=$1
 fi
 
 if [ $# -gt 1 ] ; then
-    SLEEP=$2
+    PROBE_IMPL=$2
 fi
-
-if [ $# -gt 2 ] ; then
-    DEBUG_SCRIPT=$3
-fi
-
-if [ $# -gt 3 ] ; then
-    PROBE_IMPL=$4
-fi
-
-# Sleep for 5 seconds to avoid launching readiness and liveness probes
-# at the same time
-sleep 5
 
 if [ "$DEBUG_SCRIPT" = "true" ]; then
     DEBUG_OPTIONS="--debug --logfile $LOG --loglevel DEBUG"
 fi
 
-if python $JBOSS_HOME/bin/probes/runner.py -c READY -c NOT_READY --maxruns $COUNT --sleep $SLEEP $DEBUG_OPTIONS $PROBE_IMPL; then
+if python $JBOSS_HOME/bin/probes/runner.py -c READY -c NOT_READY $DEBUG_OPTIONS $PROBE_IMPL; then
     exit 0
 fi
 

--- a/os-eap-probes/2.0/added/probes/probe/dmr.py
+++ b/os-eap-probes/2.0/added/probes/probe/dmr.py
@@ -94,11 +94,11 @@ class DmrProbe(BatchingProbe):
             response because one of the test steps failed, in which case we pass the
             response to the tests to let them decide how to handle things
             """
-            self.failUnusableResponse(response)
+            self.failUnusableResponse(response, request, url)
 
         return response.json(object_pairs_hook = OrderedDict)
 
-    def failUnusableResponse(self, response):
+    def failUnusableResponse(self, response, request, url):
         respDict = None
         try:
             respDict = response.json(object_pairs_hook = OrderedDict)

--- a/os-eap-probes/2.0/added/readinessProbe.sh
+++ b/os-eap-probes/2.0/added/readinessProbe.sh
@@ -12,26 +12,18 @@ DEBUG=${SCRIPT_DEBUG:-false}
 PROBE_IMPL="probe.eap.dmr.EapProbe probe.eap.dmr.HealthCheckProbe"
 
 if [ $# -gt 0 ] ; then
-    COUNT=$1
+    DEBUG=$1
 fi
 
 if [ $# -gt 1 ] ; then
-    SLEEP=$2
-fi
-
-if [ $# -gt 2 ] ; then
-    DEBUG=$3
-fi
-
-if [ $# -gt 3 ] ; then
-    PROBE_IMPL=$4
+    PROBE_IMPL=$2
 fi
 
 if [ "$DEBUG" = "true" ]; then
     DEBUG_OPTIONS="--debug --logfile $LOG --loglevel DEBUG"
 fi
 
-if python $JBOSS_HOME/bin/probes/runner.py -c READY --maxruns $COUNT --sleep $SLEEP $DEBUG_OPTIONS $PROBE_IMPL; then
+if python $JBOSS_HOME/bin/probes/runner.py -c READY $DEBUG_OPTIONS $PROBE_IMPL; then
     exit 0
 fi
 exit 1


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3256
Signed-off-by: Ken Wills <kwills@redhat.com>