### PR TITLE
[CLOUD-3310] Missing LOGGER-CATEGORY in openjdk11 config

### DIFF
--- a/jboss-eap72-openshift/72-openjdk11/added/standalone-openshift.xml
+++ b/jboss-eap72-openshift/72-openjdk11/added/standalone-openshift.xml
@@ -106,7 +106,8 @@
             </logger>
             <logger category="sun.rmi">
                 <level name="WARN"/>
-            </logger>
+	     </logger>
+            <!-- ##LOGGER-CATEGORY## -->
             <root-logger>
                 <level name="INFO"/>
                 <handlers>


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3310
Signed-off-by: Ken Wills <kwills@redhat.com>