### PR TITLE
[CLOUD-3321] [os-eap-datasource] Allow 'mariadb' as the functional equivalent of the 'mysql' driver

### DIFF
--- a/os-eap-datasource/1.0/added/launch/datasource-common.sh
+++ b/os-eap-datasource/1.0/added/launch/datasource-common.sh
@@ -231,7 +231,7 @@ function generate_external_datasource() {
   else
     ds=" <xa-datasource jndi-name=\"${jndi_name}\" pool-name=\"${pool_name}\" enabled=\"true\" use-java-context=\"true\" statistics-enabled=\"\${wildfly.datasources.statistics-enabled:\${wildfly.statistics-enabled:false}}\">"
     local xa_props=$(compgen -v | grep -s "${prefix}_XA_CONNECTION_PROPERTY_")
-    if [ -z "$xa_props" ] && [ "$driver" != "postgresql" ] && [ "$driver" != "mysql" ]; then
+    if [ -z "$xa_props" ] && [ "$driver" != "postgresql" ] && [ "$driver" != "mysql" ] && [ "$driver" != "mariadb" ]; then
       log_warning "At least one ${prefix}_XA_CONNECTION_PROPERTY_property for datasource ${service_name} is required. Datasource will not be configured."
       failed="true"
     else


### PR DESCRIPTION


Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>