### PR TITLE
[CLOUD-3333] - os-eap-migration fails if installed EAP image has been patched

### DIFF
--- a/os-eap-migration/added/launch/openshift-migrate-common.sh
+++ b/os-eap-migration/added/launch/openshift-migrate-common.sh
@@ -53,7 +53,9 @@ function runMigration() {
 
       if [ "${recoveryPort}" != "undefined" ] ; then
         local recoveryClass="com.arjuna.ats.arjuna.tools.RecoveryMonitor"
-        recoveryJar=$(find "${JBOSS_HOME}" -name \*.jar | xargs grep -l "${recoveryClass}")
+        # we may have > 1 jar, if that is the case we use the most recent one
+        recoveryJars=$(find "${JBOSS_HOME}" -name \*.jar | xargs grep -l "${recoveryClass}")
+        recoveryJar=$(ls -Art $recoveryJars | tail -n 1)
         if [ -n "${recoveryJar}" ] ; then
           echo "$(date): Executing synchronous recovery scan for a first time"
           java -cp "${recoveryJar}" "${recoveryClass}" -host "${recoveryHost}" -port "${recoveryPort}" -timeout 1800000


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3333
Signed-off-by: Ken Wills <kwills@redhat.com>