### PR TITLE
[CLOUD-3270] - There is no environment variable to configure the initial metaspace size

### DIFF
--- a/os-eap7-openshift/added/standalone.conf
+++ b/os-eap7-openshift/added/standalone.conf
@@ -1,6 +1,8 @@
 
 source /usr/local/dynamic-resources/dynamic_resources.sh
+export GC_METASPACE_SIZE=${GC_METASPACE_SIZE:-96}
 export GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE:-256}
+
 JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 
 # Make sure that we use /dev/urandom (CLOUD-422)

--- a/tests/features/7/gc.feature
+++ b/tests/features/7/gc.feature
@@ -55,15 +55,30 @@ Feature: Openshift OpenJDK GC tests
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=80\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=256m\s
 
-  Scenario: Check GC_MAX_METASPACE_SIZE GC configuration
+  Scenario: Check GC_METASPACE_SIZE and GC_MAX_METASPACE_SIZE GC configuration
     When container is started with env
        | variable                 | value  |
+       | GC_METASPACE_SIZE        | 60     |
        | GC_MAX_METASPACE_SIZE    | 120    |
     Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MetaspaceSize=60m\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=120m\s
+
+  Scenario: Check GC_METASPACE_SIZE and GC_MAX_METASPACE_SIZE GC configuration
+    When container is started with env
+       | variable                 | value  |
+       | GC_METASPACE_SIZE        | 60     |
+       | GC_MAX_METASPACE_SIZE    | 120    |
+    Then container log should match regex ^ *JAVA_OPTS: *.* -XX:\+UseParallelOldGC\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MinHeapFreeRatio=10\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxHeapFreeRatio=20\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:GCTimeRatio=4\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:AdaptiveSizePolicyWeight=90\s
+      And container log should match regex ^ *JAVA_OPTS: *.* -XX:MetaspaceSize=60m\s
       And container log should match regex ^ *JAVA_OPTS: *.* -XX:MaxMetaspaceSize=120m\s
 
   Scenario: Check for adjusted heap sizes


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3270
Signed-off-by: Ken Wills <kwills@redhat.com>
