### PR TITLE
CLOUD-3370 - Error in configure_logger_category.sh causes logging levels configuration to fail

### DIFF
--- a/os-eap7-launch/added/launch/configure_logger_category.sh
+++ b/os-eap7-launch/added/launch/configure_logger_category.sh
@@ -37,7 +37,7 @@ add_logger_category() {
             logger=$(echo "$i" | sed 's/ //g')
             logger_category=$(echo $logger | awk -F':' '{print $1}')
             logger_level=$(echo $logger | awk -F':' '{print $2}')
-            if [[ ! "${allowed_log_levels[@]}" =~ " ${logger_level}" ]]; then
+            if [[ ! "${allowed_log_levels[@]}" =~ "${logger_level}" ]]; then
                  log_warning "Log Level ${logger_level} is not allowed, the allowed levels are ${allowed_log_levels[@]}"
             else
                 log_info "Configuring logger category ${logger_category} with level ${logger_level:-FINE}"

--- a/os-eap7-launch/tests/bats/logging/configure-logging-category.bats
+++ b/os-eap7-launch/tests/bats/logging/configure-logging-category.bats
@@ -44,6 +44,38 @@ EOF
   [ "${result}" = "${expected}" ]
 }
 
+@test "Add ALL logger category" {
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package']" $CONFIG_FILE
+  expected=$(cat <<EOF
+<logger category="com.my.package"><level name="ALL"/></logger>
+EOF
+)
+  LOGGER_CATEGORIES=com.my.package:ALL
+  run add_logger_category
+  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package']" $CONFIG_FILE)
+  result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
+  expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
+  echo "Expected: ${expected}"
+  echo "Result: ${result}"
+  [ "${result}" = "${expected}" ]
+}
+
+@test "Add TRACE logger category" {
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package']" $CONFIG_FILE
+  expected=$(cat <<EOF
+<logger category="com.my.package"><level name="TRACE"/></logger>
+EOF
+)
+  LOGGER_CATEGORIES=com.my.package:TRACE
+  run add_logger_category
+  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package']" $CONFIG_FILE)
+  result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
+  expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
+  echo "Expected: ${expected}"
+  echo "Result: ${result}"
+  [ "${result}" = "${expected}" ]
+}
+
 @test "Add 2 logger categories" {
   #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE
   expected=$(cat <<EOF
@@ -99,6 +131,24 @@ EOF
   LOGGER_CATEGORIES=" com.my.package:DEBUG, my.other.package:ERROR, my.another.package"
   run add_logger_category
   result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger']" $CONFIG_FILE)
+  result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
+  expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
+  echo "Expected: ${expected}"
+  echo "Result: ${result}"
+  [ "${result}" = "${expected}" ]
+}
+
+@test "Add 3 logger categories with ALL and with spaces" {
+  #this is the return of xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package' or @category='my.another.package']" $CONFIG_FILE '
+  expected=$(cat <<EOF
+<logger category="com.my.package"><level name="ALL"/></logger>
+<logger category="my.other.package"><level name="ERROR"/></logger>
+<logger category="my.another.package"><level name="FINE"/></logger>
+EOF
+)
+  LOGGER_CATEGORIES=" com.my.package:ALL,my.other.package:ERROR,my.another.package"
+  run add_logger_category
+  result=$(xmllint --xpath "//*[local-name()='subsystem']//*[local-name()='logger'][@category='com.my.package' or @category='my.other.package' or @category='my.another.package']" $CONFIG_FILE)
   result="$(echo "<test>${result}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)"
   expected=$(echo "<test>${expected}</test>" | sed 's|\\n||g' | xmllint --format --noblanks -)
   echo "Expected: ${expected}"


### PR DESCRIPTION
See: https://github.com/wildfly/wildfly-cekit-modules/pull/64 for similar upstream fix.