### PR TITLE
[6.4.x] - CEKit 3.2.x build fixes for CPaaS

### DIFF
--- a/jboss-eap-logging-ext/module.yaml
+++ b/jboss-eap-logging-ext/module.yaml
@@ -7,8 +7,10 @@ execute:
   user: '185'
 
 artifacts:
-- path: javax.json-1.0.4.jar
+- name: javax.json
+  target: javax.json-1.0.4.jar
   md5: 569870f975deeeb6691fcb9bc02a9555
-- url: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
+- name: jboss-logmanager-ext
+  target: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
   md5: 3c84f54725ea5657913cf6d1610798b0
 

--- a/os-eap-db-drivers/module.yaml
+++ b/os-eap-db-drivers/module.yaml
@@ -6,9 +6,6 @@ execute:
 - script: configure.sh
   user: '185'
 packages:
-      repositories:
-          - jboss-os
-          - jboss-rhscl
       install:
           - rh-mongodb36-mongo-java-driver
           - postgresql-jdbc

--- a/os-eap-launch/module.yaml
+++ b/os-eap-launch/module.yaml
@@ -6,8 +6,6 @@ execute:
 - script: configure.sh
   user: '185'
 packages:
-      repositories:
-          - jboss-os
       install:
           - hostname
 envs:

--- a/os-eap-logging/module.yaml
+++ b/os-eap-logging/module.yaml
@@ -7,7 +7,9 @@ execute:
   user: '185'
 
 artifacts:
-- path: javax.json-1.0.4.jar
+- name: javax.json
+  target: javax.json-1.0.4.jar
   md5: 569870f975deeeb6691fcb9bc02a9555
-- url: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
+- name: jboss-logmanager-ext
+  target: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
   md5: 3c84f54725ea5657913cf6d1610798b0

--- a/os-eap-probes/module.yaml
+++ b/os-eap-probes/module.yaml
@@ -6,8 +6,6 @@ execute:
 - script: configure.sh
   user: '185'
 packages:
-      repositories:
-          - jboss-os
       install:
           - python-enum34
           - python-requests

--- a/os-eap-txnrecovery/module.yaml
+++ b/os-eap-txnrecovery/module.yaml
@@ -5,8 +5,6 @@ description: Transaction recovery migration pod script package.
 execute:
 - script: install_as_root.sh
 packages:
-    repositories:
-        - jboss-os
     install:
         - python-enum34
         - python-requests

--- a/os-eap64-modules/module.yaml
+++ b/os-eap64-modules/module.yaml
@@ -7,10 +7,13 @@ execute:
   user: '185'
 
 artifacts:
-- path: tomcat-7-valves-1.0.3.Final-redhat-1.jar
+- name: tomcat-7-valves
+  target: tomcat-7-valves-1.0.3.Final-redhat-1.jar
   md5: f286f6748e6d134ed0a9dadd8320ecd2
-- path: txn-recovery-marker-jdbc-common-1.1.2.Final-redhat-00001.jar
+- name: txn-recovery-marker-jdbc-common
+  target: txn-recovery-marker-jdbc-common-1.1.2.Final-redhat-00001.jar
   md5: 252aa2b4bcded8e5bf8a7087ad7bbbeb
-- path: txn-recovery-marker-jdbc-hibernate4-1.1.2.Final-redhat-00001.jar
+- name: txn-recovery-marker-jdbc-hibernate4
+  target: txn-recovery-marker-jdbc-hibernate4-1.1.2.Final-redhat-00001.jar
   md5: 8b6b26f587d5ef278a779ff5eef72e6c
 

--- a/os-eap64-ping/module.yaml
+++ b/os-eap64-ping/module.yaml
@@ -34,5 +34,6 @@ artifacts:
 - name: openshift-ping-kube
   target: openshift-ping-kube-1.2.5.Final-redhat-1.jar
   md5: 1cbb306ba252a71ee2c4309910b459fc
-- path: oauth-20100527.jar
+- name: oauth
+  target: oauth-20100527.jar
   md5: 91c7c70579f95b7ddee95b2143a49b41

--- a/os-eap64-sso/module.yaml
+++ b/os-eap64-sso/module.yaml
@@ -7,9 +7,9 @@ execute:
   user: '185'
 
 artifacts:
-- path: rh-sso-7.2.2-eap6-adapter.zip
-  description: "The artifact is available on the Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=57851&product=core.service.rhsso&version=7.2&downloadType=securityPatches"
-  sha256: 739f2e92615bfd874c4b2c7fd8da2d5d4d8560bd853d459f9b9fcb131becb8f9
-- path: rh-sso-7.2.2-saml-eap6-adapter.zip
-  description: "The artifact is available on the Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=57811&product=core.service.rhsso&version=7.2&downloadType=securityPatches"
-  sha256: 27ace37d175ef3023cd5aa0dcdff8e54c86fc803fc8ef38d1ab7240cb006628a
+- name: rh-sso-7.2.2-eap6-adapter.zip
+  target: rh-sso-7.2.2-eap6-adapter.zip
+  md5: cbdcf88c7b4ef3a49da3fe340dcb2201
+- name: rh-sso-7.2.2-saml-eap6-adapter.zip
+  target: rh-sso-7.2.2-saml-eap6-adapter.zip
+  md5: 7c664a275a7d11a40135bc8a413cab2e


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3377
No upstream PR, this is cekit-3.2.x build fixes for 6.4 only.
Signed-off-by: Ken Wills <kwills@redhat.com>