### PR TITLE
CLOUD-3412 - add deprecation notice for hawkular on EAP 7.2 OpenJDK 8

### DIFF
--- a/os-eap-hawkular/added/standalone.conf
+++ b/os-eap-hawkular/added/standalone.conf
@@ -1,5 +1,8 @@
 # add hawkular options
+source $JBOSS_HOME/bin/launch/logging.sh
 if [ -n "${AB_HAWKULAR_REST_URL:+x}" ]; then
+  # CLOUD-3412 - if hawkular is enabled the note that it is deprecated and will be removed in a future release
+  log_warning "Please note that the Hawkular Java Agent has been deprecated and will be removed in a future release."
   # we need to configure java logging for hawkular
   AB_HAWKULAR_AGENT_OPTS="$(source /opt/hawkular/hawkular-opts && get_hawkular_opts) -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
   JAVA_OPTS="${JAVA_OPTS} ${AB_HAWKULAR_AGENT_OPTS}"


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3412
No upstream issue, hawkular is not included in any JDK 11+ image.
Signed-off-by: Ken Wills <kwills@redhat.com>