### PR TITLE
CLOUD-3424 - invalid keytool path in openjdk11 images

### DIFF
--- a/os-eap-sso/added/keycloak.sh
+++ b/os-eap-sso/added/keycloak.sh
@@ -388,7 +388,7 @@ function configure_client() {
   then
     client_config="{\"adminUrl\":\"${endpoint}saml\""
     if [ -n "$SSO_SAML_KEYSTORE" ] && [ -n "$SSO_SAML_KEYSTORE_DIR" ] && [ -n "$SSO_SAML_CERTIFICATE_NAME" ] && [ -n "$SSO_SAML_KEYSTORE_PASSWORD" ]; then
-      $JAVA_HOME/jre/bin/keytool -export -keystore ${SSO_SAML_KEYSTORE_DIR}/${SSO_SAML_KEYSTORE} -alias $SSO_SAML_CERTIFICATE_NAME -storepass $SSO_SAML_KEYSTORE_PASSWORD -file $JBOSS_HOME/standalone/configuration/keycloak.cer
+      keytool -export -keystore ${SSO_SAML_KEYSTORE_DIR}/${SSO_SAML_KEYSTORE} -alias $SSO_SAML_CERTIFICATE_NAME -storepass $SSO_SAML_KEYSTORE_PASSWORD -file $JBOSS_HOME/standalone/configuration/keycloak.cer
       base64 $JBOSS_HOME/standalone/configuration/keycloak.cer > $JBOSS_HOME/standalone/configuration/keycloak.pem
       pem=`cat $JBOSS_HOME/standalone/configuration/keycloak.pem | sed ':a;N;$!ba;s/\n//g'`
 


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-3424
Signed-off-by: Ken Wills <kwills@redhat.com>