### PR TITLE
Fix for CLOUD-3428, Evolve behave feature tests to use latest drivers

### DIFF
--- a/tests/examples/test-app-postgres/galleon/provisioning.xml
+++ b/tests/examples/test-app-postgres/galleon/provisioning.xml
@@ -5,7 +5,7 @@
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>
-    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.5.CD.Alpha1">
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.5.CD.Alpha2">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/tests/examples/test-app-prov-mysql-postgres/galleon/provisioning.xml
+++ b/tests/examples/test-app-prov-mysql-postgres/galleon/provisioning.xml
@@ -5,7 +5,7 @@
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>
-    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.5.CD.Alpha1">
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.5.CD.Alpha2">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/tests/examples/test-app-prov-mysql/galleon/provisioning.xml
+++ b/tests/examples/test-app-prov-mysql/galleon/provisioning.xml
@@ -5,7 +5,7 @@
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>
-    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.5.CD.Alpha1">
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.5.CD.Alpha2">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/tests/features/admin.feature
+++ b/tests/features/admin.feature
@@ -41,6 +41,6 @@ Feature: EAP Openshift admin
     And file /opt/eap/standalone/configuration/mgmt-users.properties should contain kabir
 
   Scenario: check management realm extension
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-extension with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-extension with env and true
     Then container log should contain WFLYSRV0025
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ApplicationRealm on XPath  //*[local-name()='http-interface']/@security-realm

--- a/tests/features/datasource.feature
+++ b/tests/features/datasource.feature
@@ -905,7 +905,7 @@ Feature: EAP Openshift datasources
 	    Then container log should contain ERROR The list of configured datasources does not contain a datasource matching the ee default-bindings datasource specified with EE_DEFAULT_DATASOURCE='does-not-match-anything'.
 
   Scenario: check mysql datasource, galleon s2i
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-prov-mysql with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-prov-mysql with env and true
        | variable                  | value                        |
        | DB_SERVICE_PREFIX_MAPPING | test-mysql=TEST              |
        | TEST_DATABASE             | kitchensink                  |
@@ -927,7 +927,7 @@ Feature: EAP Openshift datasources
     And container log should not contain WARN The default datasource for the ee subsystem has been guessed to be
 
   Scenario: check postgresql datasource, galleon s2i
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-prov-mysql-postgres with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-prov-mysql-postgres with env and true
        | variable                  | value                            |
        | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST         |
        | TEST_DATABASE                 | kitchensink                  |
@@ -949,7 +949,7 @@ Feature: EAP Openshift datasources
     And container log should not contain WARN The default datasource for the ee subsystem has been guessed to be
 
   Scenario: check mysql and postgresql datasource, galleon s2i
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-prov-mysql-postgres with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-prov-mysql-postgres with env and true
        | variable                      | value                                                  |
        | DB_SERVICE_PREFIX_MAPPING     | test-postgresql=TEST_POSTGRESQL,test-mysql=TEST_MYSQL  |
        | TEST_MYSQL_DATABASE           | kitchensink-m                                          |

--- a/tests/features/driver.feature
+++ b/tests/features/driver.feature
@@ -7,25 +7,24 @@ Feature: EAP Openshift drivers
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='driver']
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value h2 on XPath //*[local-name()='driver']/@name
 
-
   Scenario: check postgresql driver
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-postgres with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-postgres with env and true
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='drivers']/*[local-name()='driver']
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value postgresql on XPath //*[local-name()='drivers']/*[local-name()='driver']/@name
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.postgresql.jdbc on XPath //*[local-name()='drivers']/*[local-name()='driver']/@module
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.postgresql.xa.PGXADataSource on XPath //*[local-name()='drivers']/*[local-name()='driver']/*[local-name()='xa-datasource-class']
 
   Scenario: check mysql driver
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-prov-mysql with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-prov-mysql with env and true
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='drivers']/*[local-name()='driver']
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mysql on XPath //*[local-name()='drivers']/*[local-name()='driver']/@name
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value com.mysql.jdbc on XPath //*[local-name()='drivers']/*[local-name()='driver']/@module
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value com.mysql.jdbc.jdbc2.optional.MysqlXADataSource on XPath //*[local-name()='drivers']/*[local-name()='driver']/*[local-name()='xa-datasource-class']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value com.mysql.cj.jdbc.MysqlXADataSource on XPath //*[local-name()='drivers']/*[local-name()='driver']/*[local-name()='xa-datasource-class']
 
   Scenario: check postgresql and mysql drivers
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-prov-mysql-postgres with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-prov-mysql-postgres with env and true
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='drivers']/*[local-name()='driver']
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.postgresql.jdbc on XPath //*[local-name()='drivers']/*[local-name()='driver' and @name='postgresql']/@module
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.postgresql.xa.PGXADataSource on XPath //*[local-name()='drivers']/*[local-name()='driver' and @name='postgresql']/*[local-name()='xa-datasource-class']
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value com.mysql.jdbc on XPath //*[local-name()='drivers']/*[local-name()='driver' and @name='mysql']/@module
-    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value com.mysql.jdbc.jdbc2.optional.MysqlXADataSource on XPath //*[local-name()='drivers']/*[local-name()='driver' and @name='mysql']/*[local-name()='xa-datasource-class']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value com.mysql.cj.jdbc.MysqlXADataSource on XPath //*[local-name()='drivers']/*[local-name()='driver' and @name='mysql']/*[local-name()='xa-datasource-class']

--- a/tests/features/galleon.feature
+++ b/tests/features/galleon.feature
@@ -44,7 +44,7 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /s2i-output/server/.galleon/provisioning.xml should contain value web-clustering on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
   
   Scenario: build the example, then check that cloud-server and postgresql-driver are provisioned and artifacts are downloaded
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-postgres using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-postgres
     Then s2i build log should contain Downloaded
     Then file /s2i-output/server/.galleon/provisioning.xml should exist
     Then file /opt/eap/.galleon/provisioning.xml should exist
@@ -54,7 +54,7 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /s2i-output/server/.galleon/provisioning.xml should contain value postgresql-datasource on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
 
   Scenario: build the example, then check that cloud-server and postgresql-driver are provisioned and artifacts are not downloaded
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-postgres with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-postgres with env and true
     Then s2i build log should not contain Downloaded
     Then file /s2i-output/server/.galleon/provisioning.xml should exist
     Then file /opt/eap/.galleon/provisioning.xml should exist
@@ -64,14 +64,14 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /s2i-output/server/.galleon/provisioning.xml should contain value postgresql-datasource on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
 
   Scenario: build the jaxrs example and jaxrs server from user defined server, then check that jaxrs-server is provisioned
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-jaxrs with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs with env and true
     Then file /s2i-output/server/.galleon/provisioning.xml should exist
     Then file /opt/eap/.galleon/provisioning.xml should exist
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value jaxrs-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
     Then XML file /s2i-output/server/.galleon/provisioning.xml should contain value jaxrs-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
 
   Scenario: build the jaxrs example, then check that galleon env var overrides user defined galleon server
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-jaxrs with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs with env and true
     | variable          | value                                                                                  |
     | GALLEON_PROVISION_LAYERS        | core-server |
     Then file /s2i-output/server/.galleon/provisioning.xml should exist
@@ -80,7 +80,7 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /s2i-output/server/.galleon/provisioning.xml should contain value core-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
 
   Scenario: failing to build the example due to invalid user defined galleon definition
-    Given failing s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-jaxrs with env and true using EAP7-1216
+    Given failing s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs with env and true
     | variable          | value                                                                                  |
     | GALLEON_VERSION | 0.0.0.Foo |
 
@@ -125,7 +125,7 @@ Feature: Openshift EAP galleon s2i tests
     | GALLEON_PROVISION_LAYERS        | cloud-server,foo |
 
   Scenario: Test custom settings with galleon
-   Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-settings with env and true using EAP7-1216
+   Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-settings with env and true
     | variable                     | value                                                 |
     | GALLEON_PROVISION_LAYERS     | cloud-server  |
     Then container log should contain WFLYSRV0025
@@ -140,7 +140,7 @@ Feature: Openshift EAP galleon s2i tests
     Then container log should contain WFLYSRV0025
 
  Scenario: Galleon provision cloud-server with user redefined MAVEN_ARGS
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-empty with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-empty with env and true
     | variable                        | value        |
     | MAVEN_ARGS                      | foo          |
     | GALLEON_PROVISION_LAYERS        | cloud-server |

--- a/tests/features/s2i.feature
+++ b/tests/features/s2i.feature
@@ -127,13 +127,13 @@ Feature: Openshift EAP s2i tests
     Then s2i build log should contain + log_info 'Script debugging is enabled, allowing bash commands and their arguments to be printed as they are executed'
 
   Scenario: check drivers added during s2i.
-    Given s2i build git://github.com/jfdenise/jboss-eap-modules from tests/examples/test-app-drivers with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-drivers with env and true
     Then container log should contain WFLYSRV0025
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='driver']
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value testpostgres on XPath //*[local-name()='drivers']/*[local-name()='driver']/@name
 
   Scenario: Test custom settings
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-settings with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-settings with env and true
     Then container log should contain WFLYSRV0025
     Then file /home/jboss/.m2/settings.xml should contain foo-repository
 

--- a/tests/features/security_domains.feature
+++ b/tests/features/security_domains.feature
@@ -124,14 +124,14 @@ Feature: EAP Openshift security domains
       And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value application-security on XPath //*[local-name()='security-domain'][@name='application-security'][@default-realm='application-security']/*[local-name()='realm']/@name
 
   Scenario: check other login modules
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-extension with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-extension with env and true
     Then container log should contain WFLYSRV0025
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value org.kie.security.jaas.KieLoginModule on XPath //*[local-name()='login-module']/@code
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value optional on XPath //*[local-name()='login-module' and @code="org.kie.security.jaas.KieLoginModule"]/@flag
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value deployment.ROOT.war on XPath //*[local-name()='login-module'][@code="org.kie.security.jaas.KieLoginModule"]/@module
 
   Scenario: check other login modules, galleon
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-extension with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-extension with env and true
       | variable                     | value       |
       | GALLEON_PROVISION_SERVER     | slim-default-server     |
     Then container log should contain WFLYSRV0025
@@ -140,7 +140,7 @@ Feature: EAP Openshift security domains
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value deployment.ROOT.war on XPath //*[local-name()='login-module'][@code="org.kie.security.jaas.KieLoginModule"]/@module
 
   Scenario: check other login modules, galleon legacy-security layer
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-extension with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-extension with env and true
       | variable                     | value       |
       | GALLEON_PROVISION_LAYERS     | cloud-server,legacy-security     |
     Then container log should contain WFLYSRV0025
@@ -149,14 +149,14 @@ Feature: EAP Openshift security domains
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value deployment.ROOT.war on XPath //*[local-name()='login-module'][@code="org.kie.security.jaas.KieLoginModule"]/@module
 
   Scenario: check other login modules, no security domain
-    Given s2i build git://github.com/wildfly/temp-eap-modules from tests/examples/test-app-extension with env and true using EAP7-1216
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-extension with env and true
       | variable                     | value            |
       | GALLEON_PROVISION_LAYERS     | cloud-server     |
     Then container log should contain WFLYCTL0030: No resource definition is registered for address
 
 
   Scenario: check Elytron configuration with elytron core realms security domain fail
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_CORE_REALM | true                 |
@@ -172,7 +172,7 @@ Feature: EAP Openshift security domains
       | port                       | 8080        |
 
   Scenario: check Elytron configuration with elytron core realms security domain success
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216 without running
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true using master without running
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_CORE_REALM | true                 |
@@ -188,7 +188,7 @@ Feature: EAP Openshift security domains
       | password | pass |
 
   Scenario: check Elytron configuration with elytron core realms security domain fail, galleon
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_CORE_REALM | true                 |
@@ -203,7 +203,7 @@ Feature: EAP Openshift security domains
       | port                       | 8080        |
 
   Scenario: check Elytron configuration with elytron core realms security domain success, galleon
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216 without running
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true using master without running
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_CORE_REALM | true                 |
@@ -220,7 +220,7 @@ Feature: EAP Openshift security domains
       | password | pass |
 
  Scenario: check Elytron configuration with elytron custom security domain fail
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216 without running
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true using master without running
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_USERS_PROPERTIES | empty-foo-users.properties                 |
@@ -241,7 +241,7 @@ Feature: EAP Openshift security domains
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value my-security-domain on XPath //*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:ejb3:')]/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@security-domain
 
   Scenario: check Elytron configuration with elytron custom security domain success
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216 without running
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true using master without running
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_USERS_PROPERTIES | foo-users.properties                 |
@@ -259,7 +259,7 @@ Feature: EAP Openshift security domains
       | password | pass |
 
  Scenario: check Elytron configuration with elytron custom security domain fail, galleon
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216 without running
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true using master without running
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_USERS_PROPERTIES | empty-foo-users.properties                 |
@@ -279,7 +279,7 @@ Feature: EAP Openshift security domains
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value my-security-domain on XPath //*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:undertow:')]/*[local-name()='application-security-domains']/*[local-name()='application-security-domain']/@security-domain
 
   Scenario: check Elytron configuration with elytron custom security domain success, galleon
-    Given s2i build https://github.com/wildfly/temp-eap-modules from tests/examples/test-app-web-security with env and true using EAP7-1216 without running
+    Given s2i build https://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-web-security with env and true using master without running
        | variable                   | value       |
        | ELYTRON_SECDOMAIN_NAME     | my-security-domain     |
        | ELYTRON_SECDOMAIN_USERS_PROPERTIES | foo-users.properties                 |


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/CLOUD-3428
Signed-off-by: jdenise@redhat.com
- Updated test projects to use datasources 1.0.5.CD.Alpha2
- Clean-up references to WIP branches tests projects.