### PR TITLE
Fix for WFWIP-258,Galleon Maven repo in builder image contains additional artifacts

### DIFF
--- a/jboss/container/eap/galleon/build-settings/osbs/artifacts/settings.xml
+++ b/jboss/container/eap/galleon/build-settings/osbs/artifacts/settings.xml
@@ -3,7 +3,7 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
-    <localRepository>${env.GALLEON_LOCAL_MAVEN_REPO}</localRepository>
+    <localRepository>${env.TMP_GALLEON_LOCAL_MAVEN_REPO}</localRepository>
     <profiles>
         <profile>
             <id>internal-osbs-repositories</id>

--- a/jboss/container/eap/galleon/module.yaml
+++ b/jboss/container/eap/galleon/module.yaml
@@ -34,6 +34,8 @@ envs:
   value: eap-s2i-galleon-pack
 - name: GALLEON_S2I_PRODUCER_NAME
   value: eap-s2i
+- name: DELETE_BUILD_ARTIFACTS
+  value: "true"
 
 execute:
 - script: configure.sh

--- a/tests/features/galleon.feature
+++ b/tests/features/galleon.feature
@@ -80,7 +80,7 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /s2i-output/server/.galleon/provisioning.xml should contain value core-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
 
   Scenario: failing to build the example due to invalid user defined galleon definition
-    Given failing s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs with env and true
+    Given failing s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs using master
     | variable          | value                                                                                  |
     | GALLEON_VERSION | 0.0.0.Foo |
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFWIP-258
Signed-off-by: jdenise@redhat.com

* osbs settings to use tmp galleon local cache
* Do not keep build artifacts
* Fixed test (finding, unrelated to issue).