### PR TITLE
Fix for CLOUD-3432, Licenses files should be provisioned along galleon layers

### DIFF
--- a/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/model.xml
+++ b/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/model.xml
@@ -13,6 +13,7 @@
         <package name="eap.s2i.hawkular"/>
         <package name="eap.s2i.prometheus"/>
         <package name="wildfly.s2i.mvn"/>
+        <package name="docs.licenses.merge"/>        
     </packages>
     <layers>
         <!-- required by operator to be monitored -->


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/CLOUD-3432
Signed-off-by: jdenise@redhat.com

Licenses files provisioned in all cases.