### PR TITLE
[CLOUD-3439] Redirect dynamic_resources.sh standard output to null when sourcing in standalone.conf

### DIFF
--- a/os-eap7-openshift/added/standalone.conf
+++ b/os-eap7-openshift/added/standalone.conf
@@ -1,5 +1,5 @@
 
-source /usr/local/dynamic-resources/dynamic_resources.sh
+source /usr/local/dynamic-resources/dynamic_resources.sh > /dev/null
 export GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE:-256}
 JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 


### PR DESCRIPTION
When java-default-options is sourced by any script to make use of its functions, by default prints to the standard output the calculated [JAVA_OPTS](https://github.com/jboss-openshift/cct_module/blob/master/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options#L172)

We cannot remove this echo, because it can be used by other parties to get the calculated values when sourcing it, so a workaround to avoid print this message when the server start could be to redirect to null the output when we are sourcing it in the standalone.conf file.

Jira issue: https://issues.jboss.org/browse/CLOUD-3439