### PR TITLE
[CLOUD-3444] Redirect dynamic_resources.sh standard output to null when sourcing in standalone.conf

### DIFF
--- a/os-eap7-openshift/added/standalone.conf
+++ b/os-eap7-openshift/added/standalone.conf
@@ -1,5 +1,5 @@
 
-source /usr/local/dynamic-resources/dynamic_resources.sh
+source /usr/local/dynamic-resources/dynamic_resources.sh > /dev/null
 export GC_METASPACE_SIZE=${GC_METASPACE_SIZE:-96}
 export GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE:-256}
 


### PR DESCRIPTION
When java-default-options is sourced by any script to make use of its functions, by default prints to the standard output the calculated JAVA_OPTS

We cannot remove this echo, because it can be used by other parties to get the calculated values when sourcing it, so a workaround to avoid print this message when the server start could be to redirect to null the output when we are sourcing it in the standalone.conf file.

Jira issue: https://issues.jboss.org/browse/CLOUD-3444