### PR TITLE
JBEAP-18074 - Update OpenJ9 s390x build to use official RPMs from cct_module

### DIFF
--- a/os-eap7-openshift/module.yaml
+++ b/os-eap7-openshift/module.yaml
@@ -4,7 +4,7 @@ version: '1.0'
 description: Legacy os-eap7-openshift script package.
 modules:
   install:
-  - name: os-java-run
+  - name: jboss.container.java.jvm.bash
 execute:
 - script: prepare.sh
 - script: configure.sh


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-18074
Signed-off-by: Ken Wills <kwills@redhat.com>
