### PR TITLE
[CLOUD-3452] Move GC logs to PREPEND_JAVA_OPTS to bypass the specific EAP checks

### DIFF
--- a/os-eap7-openshift/added/standalone.conf
+++ b/os-eap7-openshift/added/standalone.conf
@@ -3,6 +3,14 @@ source /usr/local/dynamic-resources/dynamic_resources.sh
 export GC_MAX_METASPACE_SIZE=${GC_MAX_METASPACE_SIZE:-256}
 JAVA_OPTS="$(adjust_java_options ${JAVA_OPTS})"
 
+# CLOUD-3188 if JAVA_DIAGNOSTICS and the JDK specific diagnostics contain any GC log configuration, move the settings to PREPEND_JAVA_OPTS
+# to bypass the specific EAP checks done on JAVA_OPTS in standalone.sh that could remove the GC EAP specific log configurations
+JDK_DIAGNOSTICS=$(jvm_specific_diagnostics)
+if [ "x$JAVA_DIAGNOSTICS" != "x" ] && [ "x{JDK_DIAGNOSTICS}" != "x" ] && grep -q "\-Xlog:gc" <<< "${JDK_DIAGNOSTICS}"; then
+  JAVA_OPTS=${JAVA_OPTS/${JDK_DIAGNOSTICS} /}
+  PREPEND_JAVA_OPTS="${PREPEND_JAVA_OPTS} ${JDK_DIAGNOSTICS}"
+fi
+
 # Make sure that we use /dev/urandom (CLOUD-422)
 JAVA_OPTS="${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom"
 


### PR DESCRIPTION
The solution is a bit hacky, but I haven't found a better approach, so maybe this one is acceptable.

EAP in standalone.sh will avoid adding any GC log file configuration if there is any JAVA_OPTS setting related to GC logs. This check clashes with the jvm_specific_diagnostics for JDK 11, where the `-Xlog:gc::utctime` decorator is enabled.

To prevent EAP skips the GC log file configuration due to the jvm_specific_diagnostics settings, we could remove the settings from the JAVA_OPTS and add them to PREPEND_JAVA_OPTS. That change will bypass the EAP specific checks. 

jira issue: https://issues.redhat.com/browse/CLOUD-3452