### PR TITLE
[CLOUD-3289] adding optional module for transaction recovery jdbc driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
+*.iml
 .project

--- a/jboss/container/eap/openshift/modules/added/modules/system/layers/openshift/io/narayana/openshift-recovery/main/module.xml
+++ b/jboss/container/eap/openshift/modules/added/modules/system/layers/openshift/io/narayana/openshift-recovery/main/module.xml
@@ -34,5 +34,6 @@
         <module name="com.mysql" optional="true"/>
         <module name="org.postgresql.jdbc" optional="true"/>
         <module name="com.mysql.jdbc" optional="true"/>
+        <module name="io.narayana.openshift-recovery.jdbc" optional="true"/>
     </dependencies>
 </module>

--- a/jboss/container/eap/openshift/modules/configure.sh
+++ b/jboss/container/eap/openshift/modules/configure.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
-VERSION_TXN_MARKER="1.1.2.Final-redhat-00001"
+VERSION_TXN_MARKER="1.1.4.Final-redhat-00001"
 
 # Add new "openshift" layer
 cp -rp --remove-destination "$ADDED_DIR/modules" "$JBOSS_HOME/"

--- a/jboss/container/eap/openshift/modules/module.yaml
+++ b/jboss/container/eap/openshift/modules/module.yaml
@@ -8,8 +8,8 @@ execute:
 
 artifacts:
 - name: txn-recovery-marker-jdbc-common
-  target: txn-recovery-marker-jdbc-common-1.1.2.Final-redhat-00001.jar
-  md5: 252aa2b4bcded8e5bf8a7087ad7bbbeb
+  target: txn-recovery-marker-jdbc-common-1.1.4.Final-redhat-00001.jar
+  md5: 305aa706018b1089e5b82528b601541f
 - name: txn-recovery-marker-jdbc-hibernate5
-  target: txn-recovery-marker-jdbc-hibernate5-1.1.2.Final-redhat-00001.jar
-  md5: cd68ad886a759d21f8dd0cb7646601ee
+  target: txn-recovery-marker-jdbc-hibernate5-1.1.4.Final-redhat-00001.jar
+  md5: 99f2a2e68fb92273b8016e2b199fbd91

--- a/os-eap-txnrecovery/bash/added/logging.properties
+++ b/os-eap-txnrecovery/bash/added/logging.properties
@@ -1,4 +1,7 @@
-handlers = java.util.logging.ConsoleHandler
-java.util.logging.ConsoleHandler.level = WARN
-java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
-.level = WARN
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+
+.level=INFO
+org.hibernate.level=SEVERE
+org.hibernate.handler=java.util.logging.ConsoleHandler

--- a/tests/features/tx-recovery.feature
+++ b/tests/features/tx-recovery.feature
@@ -1,0 +1,56 @@
+@jboss-eap-7 @jboss-eap-7-tech-preview
+Feature: EAP Openshift transaction scaledown recovery on partition PV
+
+Scenario: Cannot connect to an Oracle database with transaction JDBC object store scaledown processing
+    When container is started with command bash
+       | variable                         | value                                 |
+       | JDBC_SKIP_RECOVERY               | false                                 |
+       | TX_DATABASE_PREFIX_MAPPING       | TEST_ORACLE                           |
+       | TEST_ORACLE_JNDI                 | java:/jboss/datasources/testds        |
+       | TEST_ORACLE_USERNAME             | txnuser                               |
+       | TEST_ORACLE_PASSWORD             | txnpassword                           |
+       | TEST_ORACLE_SERVICE_HOST         | 10.1.1.1                              |
+       | TEST_ORACLE_SERVICE_PORT         | 1521                                  |
+       | TEST_ORACLE_DATABASE             | XE                                    |
+       | JDBC_RECOVERY_CUSTOM_JDBC_MODULE | com.oracle.ojdbc                      |
+       | NODE_NAME                        | Test-Store-Node-Name                  |
+    Then copy features/jboss-eap-modules/scripts/datasource/add-standard-jdbc-store-datasources.cli to /tmp in container
+    And run /opt/eap/bin/jboss-cli.sh --file=/tmp/add-standard-jdbc-store-datasources.cli in container once
+    And run script -c /opt/eap/bin/openshift-launch.sh /tmp/boot.log in container and detach
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='datasource'] and wait 30 seconds
+    And file /opt/eap/modules/system/layers/openshift/io/narayana/openshift-recovery/jdbc/main/module.xml should contain com.oracle.ojdbc
+    And file /tmp/boot.log should contain java.lang.ClassNotFoundException: Could not load requested class : oracle.jdbc.driver.OracleDriver
+
+Scenario: Fail to run jdbc recovery when unknown database type is specified
+    When container is started with command bash
+       | variable                     | value                                    |
+       | JDBC_SKIP_RECOVERY           | false                                    |
+       | TX_DATABASE_PREFIX_MAPPING   | TEST                                     |
+       | TEST_DRIVER                  | unknown                                  |
+       | TEST_USERNAME                | txnuser                                  |
+       | TEST_PASSWORD                | txnpassword                              |
+       | TEST_SERVICE_HOST            | 10.1.1.1                                 |
+       | TEST_SERVICE_PORT            | 5432                                     |
+       | TEST_DATABASE                | txndb                                    |
+       | NODE_NAME                    | Test-Store-Node-Name                     |
+    Then copy features/jboss-eap-modules/scripts/datasource/add-standard-jdbc-store-datasources.cli to /tmp in container
+    And run /opt/eap/bin/jboss-cli.sh --file=/tmp/add-standard-jdbc-store-datasources.cli in container once
+    And run script -c /opt/eap/bin/openshift-launch.sh /tmp/boot.log in container and detach
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='datasource'] and wait 30 seconds
+    And file /tmp/boot.log should contain There is not defined variable 'TEST_DATABASE_TYPE' and the PREFIX part of the TX_DATABASE_PREFIX_MAPPING='TEST' does not contain information on database type.
+
+Scenario: Fail to run jdbc recovery when host or url is not specified
+    When container is started with command bash
+       | variable                     | value                                    |
+       | JDBC_SKIP_RECOVERY           | false                                    |
+       | TX_DATABASE_PREFIX_MAPPING   | TEST                                     |
+       | TEST_USERNAME                | txnuser                                  |
+       | TEST_PASSWORD                | txnpassword                              |
+       | TEST_SERVICE_PORT            | 5432                                     |
+       | TEST_DATABASE                | txndb                                    |
+       | NODE_NAME                    | Test-Store-Node-Name                     |
+    Then copy features/jboss-eap-modules/scripts/datasource/add-standard-jdbc-store-datasources.cli to /tmp in container
+    And run /opt/eap/bin/jboss-cli.sh --file=/tmp/add-standard-jdbc-store-datasources.cli in container once
+    And run script -c /opt/eap/bin/openshift-launch.sh /tmp/boot.log in container and detach
+    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='datasource'] and wait 30 seconds
+    And file /tmp/boot.log should contain ERROR The image startup could fail. For disabling transaction database scaledown processing do NOT use property TX_DATABASE_PREFIX_MAPPING.


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-3289

Adding a way to use non-postgresql and non-mysql JDBC drivers and configure the connection for the transaction recovery scaledown processing when JDBC object store is used.

This change, fixes and code additions and released jbosstm tools `.jars`, expects for user defining manually a module named as `io.narayana.openshift-recovery.jdbc` which is the place where JDBC driver jar files are stored and used by the recovery module `io.narayana.openshift-recovery` from.

The module may be created with galleon feature pack - e.g. I did it for oracle like this: https://github.com/ochaloup/wildfly-datasources-galleon-pack/commit/3d475603638016b6a21843f1832e148136ef9c71.