### PR TITLE
Fix old module ref

### DIFF
--- a/os-eap7-openshift/module.yaml
+++ b/os-eap7-openshift/module.yaml
@@ -4,7 +4,7 @@ version: '1.0'
 description: Legacy os-eap7-openshift script package.
 modules:
   install:
-  - name: os-java-run
+  - name: jboss.container.java.jvm.bash
 execute:
 - script: prepare.sh
 - script: configure.sh


### PR DESCRIPTION
The module name was changed here: https://github.com/jboss-openshift/cct_module/commit/ab8c07e3582004c4745810bbb3df58346b09c6e0

This blocks RH-SSO builds.
@luck3y can you please review?