### PR TITLE
Fix for CLOUD-3471, Can't run multiple server during migration

### DIFF
--- a/os-eap-migration/added/launch/openshift-migrate-common.sh
+++ b/os-eap-migration/added/launch/openshift-migrate-common.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 # Openshift EAP common migration script
 
-source ${JBOSS_HOME}/bin/launch/launch.sh
 source ${JBOSS_HOME}/bin/probe_common.sh
 source /opt/partition/partitionPV.sh
 
@@ -14,9 +13,6 @@ function runMigration() {
   [ "x$count" != "x" ] && export NODE_NAME="${NODE_NAME:-node}-${count}"
 
   cp -f ${STANDALONE_XML_COPY} ${STANDALONE_XML}
-
-  # exposed by wildfly-cekit-modules
-  configure_server
 
   echo "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION"
 

--- a/os-eap-txnrecovery/bash/added/partitionPV.sh
+++ b/os-eap-txnrecovery/bash/added/partitionPV.sh
@@ -174,6 +174,11 @@ function migratePV() {
     done
   fi
 
+  # server can only be configured once due to CLI script being executed
+  # doing it before the loop that will start a server per directory.
+  source $JBOSS_HOME/bin/launch/launch.sh
+  configure_server
+
   while true ; do
 
     if $IS_TX_SQL_BACKEND; then


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3471
Signed-off-by: JF Denise jdenise@redhat.com

Configure the server only once prior to start migrations.