### PR TITLE
Upgrade tests to datasources 1.0.7.CD.Alpha1

### DIFF
--- a/tests/examples/test-app-postgres/galleon/provisioning.xml
+++ b/tests/examples/test-app-postgres/galleon/provisioning.xml
@@ -5,7 +5,7 @@
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>
-    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.6.CD.Final">
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.7.CD.Alpha1">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/tests/examples/test-app-prov-mysql-postgres/galleon/provisioning.xml
+++ b/tests/examples/test-app-prov-mysql-postgres/galleon/provisioning.xml
@@ -5,7 +5,7 @@
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>
-    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.6.CD.Final">
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.7.CD.Alpha1">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>

--- a/tests/examples/test-app-prov-mysql/galleon/provisioning.xml
+++ b/tests/examples/test-app-prov-mysql/galleon/provisioning.xml
@@ -5,7 +5,7 @@
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>
-    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.6.CD.Final">
+    <feature-pack location="org.wildfly:wildfly-datasources-galleon-pack:1.0.7.CD.Alpha1">
         <default-configs inherit="false"/>
         <packages inherit="false"/>
     </feature-pack>


### PR DESCRIPTION
Upgrade tests dependencies of wildfly-datasources FP. Required now that no more producers are present in the image. 