### PR TITLE
Do not exclude instanceDir variable from double quoting

### DIFF
--- a/jboss/container/eap/launch/added/openshift-launch.sh
+++ b/jboss/container/eap/launch/added/openshift-launch.sh
@@ -5,7 +5,7 @@ source ${JBOSS_HOME}/bin/launch/launch.sh
 
 function runServer() {
   local instanceDir=$1
-  launchServer "$JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 0.0.0.0 -Djboss.server.data.dir="$instanceDir" -Dwildfly.statistics-enabled=true"
+  launchServer "$JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 0.0.0.0 -Djboss.server.data.dir=${instanceDir} -Dwildfly.statistics-enabled=true"
 }
 
 function init_data_dir() {


### PR DESCRIPTION
This PR follows up https://github.com/jboss-container-images/jboss-eap-modules/pull/178

It just keeps the $instanceDir variable inside of the double-quotes. `launchServer` expects only one argument, and keeping the variable inside could prevent a wrong argument interpretation if $instanceDir contains a blank space.