### PR TITLE
[CLOUD-3499] Test case we do not see WFLYCTL0056 after CLI server con…

### DIFF
--- a/tests/examples/test-embedded-at-s2i/.s2i/environment
+++ b/tests/examples/test-embedded-at-s2i/.s2i/environment
@@ -1,0 +1,1 @@
+S2I_IMAGE_SOURCE_MOUNTS=extensions

--- a/tests/examples/test-embedded-at-s2i/extensions/extension.cli
+++ b/tests/examples/test-embedded-at-s2i/extensions/extension.cli
@@ -1,0 +1,3 @@
+embed-server --std-out=echo --server-config=standalone-openshift.xml
+/system-property=foo:add(value=bar)
+stop-embedded-server

--- a/tests/examples/test-embedded-at-s2i/extensions/install.sh
+++ b/tests/examples/test-embedded-at-s2i/extensions/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -x
+echo "Running $PWD/install.sh"
+
+injected_dir=$1
+${JBOSS_HOME}/bin/jboss-cli.sh --file=${injected_dir}/extension.cli

--- a/tests/features/s2i.feature
+++ b/tests/features/s2i.feature
@@ -143,3 +143,8 @@ Feature: Openshift EAP s2i tests
      | MAVEN_SETTINGS_XML           | /home/jboss/../jboss/../jboss/.m2/settings.xml |
     Then s2i build log should contain /home/jboss/../jboss/../jboss/.m2/settings.xml
     Then container log should contain WFLYSRV0025
+
+  Scenario: Test embedded server configuration during S2I
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-embedded-at-s2i with env and true using master
+    Then container log should not contain WFLYCTL0056
+    Then container log should contain WFLYSRV0025


### PR DESCRIPTION
…figuration during S2I

Test case for https://github.com/wildfly/wildfly-cekit-modules/pull/159

jira issue: https://issues.redhat.com/browse/CLOUD-3499