### PR TITLE
[CLOUD-3548] Update the name of the Maven S2I module to the cct_module's 0.41.0 form

### DIFF
--- a/jboss/container/eap/s2i/bash/README.adoc
+++ b/jboss/container/eap/s2i/bash/README.adoc
@@ -51,7 +51,7 @@ No additional RPM package repositories are required to install listed RPMs.
 
 The following modules will be installed with this module:
 
-link:../../../../../jboss/container/maven/s2i/bash/README.adoc[jboss.container.maven.s2i.bash]
+link:../../../../../jboss/container/maven/s2i/README.adoc[jboss.container.maven.s2i]
 
 link:../../../../../jboss/container/util/logging/bash/README.adoc[jboss.container.util.logging.bash]
 

--- a/jboss/container/eap/s2i/bash/module.yaml
+++ b/jboss/container/eap/s2i/bash/module.yaml
@@ -15,5 +15,5 @@ execute:
 
 modules:
   install:
-  - name: jboss.container.maven.s2i.bash
+  - name: jboss.container.maven.s2i
   - name: jboss.container.util.logging.bash


### PR DESCRIPTION
    [CLOUD-3548] Update the name of the Maven S2I module to the cct_module's 0.41.0 form

    Replace 'jboss.container.maven.s2i.bash' with 'jboss.container.maven.s2i'
    as used in 0.41.0 tag of the cct_module. See:
      https://github.com/jboss-openshift/cct_module/pull/372/files
    
    for details
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
    https://issues.redhat.com/browse/CLOUD-3548