### PR TITLE
[CLOUD-3551] Update path of Jolokia's JVM agent JAR in existing jboss-eap-modules CCT tests too

### DIFF
--- a/tests/features/6/basic.feature
+++ b/tests/features/6/basic.feature
@@ -65,7 +65,7 @@ Feature: Openshift EAP common tests (EAP and EAP derived images)
 
   Scenario: Check if jolokia is configured correctly
     When container is ready
-    Then container log should contain -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
+    Then container log should contain -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
 
   Scenario: jgroups-encrypt
     When container is started with env

--- a/tests/features/7/basic.feature
+++ b/tests/features/7/basic.feature
@@ -74,7 +74,7 @@ Feature: Common EAP tests
 
   Scenario: Check if jolokia is configured correctly
     When container is ready
-    Then container log should contain -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
+    Then container log should contain -javaagent:/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
   # https://issues.jboss.org/browse/CLOUD-295


### PR DESCRIPTION
    [CLOUD-3551] Update path of Jolokia's JVM agent JAR in existing jboss-eap-modules CCT tests too
    
    Recent 3bee8b7 cct_module change moved Jolokia's JVM agent JAR from former
    "/opt/jboss/container/jolokia/jolokia.jar" path to the new
    "/usr/share/java/jolokia-jvm-agent/jolokia-jvm.jar" one
    
    Update the existing jboss-eap-modules CCT module Jolokia tests too, so they expect
    the new location in the pod log during the test
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>
