### PR TITLE
Fix for CLOUD-3555, Upgrade to RH-SSO 7.4 Image and adapter

### DIFF
--- a/os-eap70-sso/configure.sh
+++ b/os-eap70-sso/configure.sh
@@ -4,8 +4,8 @@ SCRIPT_DIR=$(dirname $0)
 ADDED_DIR=${SCRIPT_DIR}/added
 SOURCES_DIR="/tmp/artifacts"
 
-unzip -o $SOURCES_DIR/keycloak-wildfly-adapter-dist-9.0.0.zip -d $JBOSS_HOME
-unzip -o $SOURCES_DIR/keycloak-saml-wildfly-adapter-dist-9.0.0.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/rh-sso-7.4.0-eap7-adapter.zip -d $JBOSS_HOME
+unzip -o $SOURCES_DIR/rh-sso-7.4.0-saml-eap7-adapter.zip -d $JBOSS_HOME
 
 chown -R jboss:root $JBOSS_HOME
 chmod -R g+rwX $JBOSS_HOME

--- a/os-eap70-sso/module.yaml
+++ b/os-eap70-sso/module.yaml
@@ -7,9 +7,9 @@ execute:
   user: '185'
 
 artifacts:
-- name: keycloak-wildfly-adapter-dist-9.0.0
-  target: keycloak-wildfly-adapter-dist-9.0.0.zip
-  url: http://indy.psi.redhat.com/api/content/maven/group/temporary-builds/org/keycloak/keycloak-wildfly-adapter-dist/9.0.0.temporary-redhat-00088/keycloak-wildfly-adapter-dist-9.0.0.temporary-redhat-00088.zip
-- name: keycloak-saml-wildfly-adapter-dist-9.0.0
-  target: keycloak-saml-wildfly-adapter-dist-9.0.0.zip
-  url: http://indy.psi.redhat.com/api/content/maven/group/temporary-builds/org/keycloak/keycloak-saml-wildfly-adapter-dist/9.0.0.temporary-redhat-00088/keycloak-saml-wildfly-adapter-dist-9.0.0.temporary-redhat-00088.zip
+- name: rh-sso-7.4.0-eap7-adapter
+  target: rh-sso-7.4.0-eap7-adapter.zip
+  md5: 045e97f51e4df0dd708dc784d21b44d0
+- name: rh-sso-7.4.0-saml-eap7-adapter
+  target: rh-sso-7.4.0-saml-eap7-adapter.zip
+  md5: 64875c45a977f769c33da8d47e9a3ead  


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3555
Handle the adapter part bundled in the default server.