### PR TITLE
[EAP 7.3.x and XP 1.0] Fix for CLOUD-3650, Support patched image builder Maven repository

### DIFF
--- a/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/patching.sh
+++ b/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/patching.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mavenRepo="$1"
+if [ -f "$mavenRepo/patches.xml" ]; then
+  echo "The maven repository has been patched, setting patches in galleon feature-pack."
+  patches=`cat "$mavenRepo/patches.xml" | sed ':a;N;$!ba;s/\n//g'`
+  sed -i "s|<!-- ##PATCHES## -->|$patches|" "${GALLEON_FP_PATH}/wildfly-user-feature-pack-build.xml"
+  echo "wildfly-user-feature-pack-build.xml content:"
+  cat "${GALLEON_FP_PATH}/wildfly-user-feature-pack-build.xml"
+fi

--- a/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
+++ b/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
@@ -20,8 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="org.jboss.eap.galleon.s2i:eap-s2i-galleon-pack">
-
+<build xmlns="urn:wildfly:feature-pack-build:3.2" producer="org.jboss.eap.galleon.s2i:eap-s2i-galleon-pack">
     <transitive>
         <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>
@@ -35,6 +34,7 @@
             <name>org.wildfly:wildfly-ee-galleon-pack</name>
             <packages inherit="true"/>
             <default-configs inherit="true"/>
+            <!-- ##PATCHES## -->
         </dependency>
     </dependencies>
 </build>

--- a/jboss/container/eap/galleon/config/mp/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
+++ b/jboss/container/eap/galleon/config/mp/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/wildfly-user-feature-pack-build.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.1" producer="org.jboss.eap.galleon.s2i:eap-s2i-galleon-pack">
+<build xmlns="urn:wildfly:feature-pack-build:3.2" producer="org.jboss.eap.galleon.s2i:eap-s2i-galleon-pack">
 
     <transitive>
         <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
@@ -38,6 +38,7 @@
             <name>org.wildfly:wildfly-galleon-pack</name>
             <packages inherit="true"/>
             <default-configs inherit="true"/>
+            <!-- ##PATCHES## -->
         </dependency>
     </dependencies>
 </build>

--- a/jboss/container/eap/galleon/module.yaml
+++ b/jboss/container/eap/galleon/module.yaml
@@ -8,6 +8,8 @@ envs:
   value: "18.0.0.Final"
 - name: GALLEON_DEFINITIONS
   value: /opt/jboss/container/eap/galleon/definitions
+- name: GALLEON_MAVEN_REPO_HOOK_SCRIPT
+  value: /opt/jboss/container/eap/galleon/patching.sh
 - name: GALLEON_DEFAULT_SERVER
   value: /opt/jboss/container/eap/galleon/definitions/slim-default-server
 - name: GALLEON_DEFAULT_FAT_SERVER


### PR DESCRIPTION
Fix for: https://issues.redhat.com/browse/CLOUD-3651
This fix depends on : https://github.com/wildfly/wildfly-cekit-modules/pull/188

* Introduce new script that runs once the maven repository has been unzipped. The script patches the wildfly-user-feature-pack-build.xml with the set of patches present in the maven repository (if any).
