### PR TITLE
[CLOUD-3681] Revert CLOUD-3548

### DIFF
--- a/jboss/container/eap/s2i/bash/README.adoc
+++ b/jboss/container/eap/s2i/bash/README.adoc
@@ -51,7 +51,7 @@ No additional RPM package repositories are required to install listed RPMs.
 
 The following modules will be installed with this module:
 
-link:../../../../../jboss/container/maven/s2i/README.adoc[jboss.container.maven.s2i]
+link:../../../../../jboss/container/maven/s2i/bash/README.adoc[jboss.container.maven.s2i.bash]
 
 link:../../../../../jboss/container/util/logging/bash/README.adoc[jboss.container.util.logging.bash]
 

--- a/jboss/container/eap/s2i/bash/module.yaml
+++ b/jboss/container/eap/s2i/bash/module.yaml
@@ -15,5 +15,5 @@ execute:
 
 modules:
   install:
-  - name: jboss.container.maven.s2i
+  - name: jboss.container.maven.s2i.bash
   - name: jboss.container.util.logging.bash


### PR DESCRIPTION
FYI, since we have 7.2 pinned to sprint-27, and it will never move off this branch, we need to revert this for now. 

We'll update the 7.3.x-legacy and master branches for new cct_modules instead.

Issue: https://issues.redhat.com/browse/CLOUD-3681

Signed-off-by: Daniel Kreling <dkreling@redhat.com>

