### PR TITLE
[CLOUD-3682] Update txn-recovery-marker-jdbc (narayana) md5 value

### DIFF
--- a/jboss-eap-cd-openshift-modules/module.yaml
+++ b/jboss-eap-cd-openshift-modules/module.yaml
@@ -8,6 +8,6 @@ execute:
 
 artifacts:
 - path: txn-recovery-marker-jdbc-common-1.1.2.Final-redhat-00001.jar
-  md5: 252aa2b4bcded8e5bf8a7087ad7bbbeb
+  md5: 874d791e82393006b0d2e621d08fbe00
 - path: txn-recovery-marker-jdbc-hibernate5-1.1.2.Final-redhat-00001.jar
-  md5: cd68ad886a759d21f8dd0cb7646601ee
+  md5: 7f8f5a79f47a354fd1a548428ced7b5b

--- a/os-eap64-modules/module.yaml
+++ b/os-eap64-modules/module.yaml
@@ -12,8 +12,8 @@ artifacts:
   md5: f286f6748e6d134ed0a9dadd8320ecd2
 - name: txn-recovery-marker-jdbc-common
   target: txn-recovery-marker-jdbc-common-1.1.2.Final-redhat-00001.jar
-  md5: 252aa2b4bcded8e5bf8a7087ad7bbbeb
+  md5: 874d791e82393006b0d2e621d08fbe00
 - name: txn-recovery-marker-jdbc-hibernate4
   target: txn-recovery-marker-jdbc-hibernate4-1.1.2.Final-redhat-00001.jar
-  md5: 8b6b26f587d5ef278a779ff5eef72e6c
+  md5: bf96fa27393838ee81c6bf885c153505
 

--- a/os-eap71-modules/module.yaml
+++ b/os-eap71-modules/module.yaml
@@ -8,6 +8,6 @@ execute:
 
 artifacts:
 - path: txn-recovery-marker-jdbc-common-1.1.2.Final-redhat-00001.jar
-  md5: 252aa2b4bcded8e5bf8a7087ad7bbbeb
+  md5: 874d791e82393006b0d2e621d08fbe00
 - path: txn-recovery-marker-jdbc-hibernate5-1.1.2.Final-redhat-00001.jar
-  md5: cd68ad886a759d21f8dd0cb7646601ee
+  md5: 7f8f5a79f47a354fd1a548428ced7b5b


### PR DESCRIPTION
The txn-recovery-marker-jdbc build was deleted from Brew and cause Freshmaker faill to rebuild images.

Another build was generated with the same version, but the metadata of the artifacts have changed.
The values should be fixed in the Openshift code.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>