### PR TITLE
Fix for CLOUD-3771, Disable elytron security that core-tools layer brings to default config

### DIFF
--- a/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -13,6 +13,17 @@
     <feature-group name="sso"/>
 
     <!-- management -->
+    <!-- remove elytron security that core-tools bring, we should be able to exclude management but we can't due to GAL-308 -->
+    <!-- START workaround GAL-308 -->
+    <exclude spec="core-service.management.access.identity"/>
+    <feature spec="core-service.management.management-interface.http-interface">
+        <param name="socket-binding" value="management-http"/>
+        <unset param="http-authentication-factory"/>
+        <feature spec="core-service.management.management-interface.http-interface.http-upgrade">
+            <unset param="sasl-authentication-factory"/>
+        </feature>
+    </feature>
+    <!-- END workaround GAL-308 -->
     <exclude spec="subsystem.core-management"/>
     <exclude feature-id="core-service.management.security-realm.server-identity.ssl:security-realm=ApplicationRealm"/>
     <feature-group name="os-management"/>

--- a/tests/features/sso.feature
+++ b/tests/features/sso.feature
@@ -1,3 +1,4 @@
+
 @jboss-eap-7 @jboss-eap-7-tech-preview
 Feature: OpenShift EAP SSO tests
 
@@ -207,7 +208,9 @@ Feature: OpenShift EAP SSO tests
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value /tombrady on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/@logoutPage       
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='Keys']/*[local-name()='Key']/@signing 
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value idp on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='IDP']/@entityID 
-
+ 
+  @ignore 
+  # we can't provision an unsecure configuration.
   Scenario: SSO, no elytron should give error
     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts from . with env and true using 7.0.x-ose
        | variable                   | value         |


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3771