### PR TITLE
7.3.4 and XP1.0.x galleon adjustments

### DIFF
--- a/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -14,6 +14,17 @@
     <feature-group name="sso"/>
 
     <!-- management -->
+    <!-- remove elytron security that core-tools bring, we should be able to exclude management but we can't due to GAL-308 -->
+    <!-- START workaround GAL-308 -->
+    <exclude spec="core-service.management.access.identity"/>
+    <feature spec="core-service.management.management-interface.http-interface">
+        <param name="socket-binding" value="management-http"/>
+        <unset param="http-authentication-factory"/>
+        <feature spec="core-service.management.management-interface.http-interface.http-upgrade">
+            <unset param="sasl-authentication-factory"/>
+        </feature>
+    </feature>
+    <!-- END workaround GAL-308 -->
     <exclude spec="subsystem.core-management"/>
     <exclude feature-id="core-service.management.security-realm.server-identity.ssl:security-realm=ApplicationRealm"/>
     <feature-group name="os-management"/>

--- a/jboss/container/eap/galleon/eap73-compat/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
+++ b/jboss/container/eap/galleon/eap73-compat/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/layers/standalone/datasources-web-server/layer-spec.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:1.0" name="datasources-web-server">
+    <packages>
+        <package name="org.jboss.as.security"/>
+    </packages>
+</layer-spec>

--- a/jboss/container/eap/galleon/eap73-compat/configure.sh
+++ b/jboss/container/eap/galleon/eap73-compat/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Configure module
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ARTIFACTS_DIR=${SCRIPT_DIR}/artifacts
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R ug+rwX $SCRIPT_DIR
+
+pushd ${ARTIFACTS_DIR}
+cp -pr * /
+popd

--- a/jboss/container/eap/galleon/eap73-compat/module.yaml
+++ b/jboss/container/eap/galleon/eap73-compat/module.yaml
@@ -1,0 +1,7 @@
+schema_version: 1
+name: jboss.container.eap.galleon.eap73-compat
+version: '1.0'
+description: Galleon changes require to keep backward compatibility with EAP 7.3 GA.
+
+execute:
+- script: configure.sh

--- a/tests/features/sso.feature
+++ b/tests/features/sso.feature
@@ -177,6 +177,8 @@ Feature: OpenShift EAP SSO tests
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value true on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='Keys']/*[local-name()='Key']/@signing 
     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value idp on XPath //*[local-name()='secure-deployment'][@name="app-profile-saml.war"]/*[local-name()='SP']/*[local-name()='IDP']/@entityID 
 
+  @ignore 
+  # we can't provision an unsecure configuration.
   Scenario: SSO, no elytron should give error
     Given s2i build https://github.com/redhat-developer/redhat-sso-quickstarts from . with env and true using 7.0.x-ose
        | variable                   | value         |


### PR DESCRIPTION
Issues:
https://issues.redhat.com/browse/CLOUD-3809
https://issues.redhat.com/browse/CLOUD-3771

Introduce new eap73-compact cekit module and reset management interface secured with elytron from default config.