### PR TITLE
[CLOUD-3470] Add behave tests for jpa-dist and ejb-dist-cache

### DIFF
--- a/tests/features/galleon.feature
+++ b/tests/features/galleon.feature
@@ -260,6 +260,67 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value cloud-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value observability on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='exclude']/@name
 
+   Scenario: Test jaxrs-server -jpa +jpa-distributed
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jpa2lc with env and True using master
+      | variable                             | value                                                    |
+      | GALLEON_PROVISION_LAYERS             | jaxrs-server,-jpa,jpa-distributed,h2-default-datasource  |
+    Then container log should contain WFLYSRV0025
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-jpa2lc                        |
+      | port                  | 8080                                    |
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-jpa2lc/create/1               |
+      | port                  | 8080                                    |
+      | expected_phrase       | 1 created                               |
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-jpa2lc/isInCache/1            |
+      | port                  | 8080                                    |
+      | expected_phrase       | true                                    |
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-jpa2lc/cache/1                |
+      | port                  | 8080                                    |
+      | expected_phrase       | 1                                       |
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-jpa2lc/evict/1                |
+      | port                  | 8080                                    |
+      | expected_phrase       | 1 evict                                 |
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-jpa2lc/isInCache/1            |
+      | port                  | 8080                                    |
+      | expected_phrase       | false                                   |
+    Then XML file /opt/eap/.galleon/provisioning.xml should contain value jaxrs-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
+    Then XML file /opt/eap/.galleon/provisioning.xml should contain value jpa-distributed on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
+    Then XML file /opt/eap/.galleon/provisioning.xml should contain value jpa on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='exclude']/@name
+
+  Scenario: Test jaxrs-server +ejb-lite, -ejb-local-cache +ejb-dist-cache. Verify JGroups configuration added by ejb-dist-cache
+    Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-ejb with env and True using master
+      | variable                             | value                                                    |
+      | GALLEON_PROVISION_LAYERS             | jaxrs-server,ejb-lite,-ejb-local-cache,ejb-dist-cache    |
+    Then container log should contain WFLYSRV0025
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-ejb                           |
+      | port                  | 8080                                    |
+    Then check that page is served
+      | property              | value                                   |
+      | path                  | /test-app-ejb/messages/hello            |
+      | port                  | 8080                                    |
+      | expected_phrase       | sfsb_hello                              |
+    Then XML file /opt/eap/.galleon/provisioning.xml should contain value jaxrs-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
+    Then XML file /opt/eap/.galleon/provisioning.xml should contain value ejb-dist-cache on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
+    Then XML file /opt/eap/.galleon/provisioning.xml should contain value ejb-local-cache on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='exclude']/@name
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='channel'][@name='ee' and @stack='tcp']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='transport'][@type='TCP' and @socket-binding='jgroups-tcp']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='transport'][@type='UDP' and @socket-binding='jgroups-udp']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='stack'][@name='tcp']/*[local-name()='protocol' and @type='MPING']
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 0 elements on XPath //*[local-name()='subsystem' and starts-with(namespace-uri(), 'urn:jboss:domain:jgroups:')]//*[local-name()='stack'][@name='udp']/*[local-name()='protocol' and @type='PING']
+
 # CLOUD-3949
 @ignore 
   Scenario: Test cloud-server, exclude open-tracing


### PR DESCRIPTION
Add behave tests to verify jpa-dist and ejb-dist-cache Galleon layers

Jira issue: https://issues.redhat.com/browse/CLOUD-3470
Requires: https://github.com/jboss-container-images/jboss-eap-modules/pull/218