### PR TITLE
CLOUD-3509 correct misspelling of keystore

### DIFF
--- a/tests/features/basic.feature
+++ b/tests/features/basic.feature
@@ -167,7 +167,7 @@ Feature: Common EAP tests
        | JGROUPS_PING_PROTOCOL                        | dns.DNS_PING                            |
        | OPENSHIFT_DNS_PING_SERVICE_NAME              | ping-service                            |
        | JGROUPS_CLUSTER_PASSWORD                     | P@ssw0rd                                |
-    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keysore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keystore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
   Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_NAME defined
@@ -178,7 +178,7 @@ Feature: Common EAP tests
        | JGROUPS_PING_PROTOCOL                        | dns.DNS_PING                            |
        | OPENSHIFT_DNS_PING_SERVICE_NAME              | ping-service                            |
        | JGROUPS_CLUSTER_PASSWORD                     | P@ssw0rd                                |
-    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keysore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keystore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
   Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_PASSWORD defined
@@ -189,7 +189,7 @@ Feature: Common EAP tests
        | JGROUPS_PING_PROTOCOL                        | dns.DNS_PING                            |
        | OPENSHIFT_DNS_PING_SERVICE_NAME              | ping-service                            |
        | JGROUPS_CLUSTER_PASSWORD                     | P@ssw0rd                                |
-    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keysore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keystore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
   Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_KEYSTORE_DIR defined
@@ -200,7 +200,7 @@ Feature: Common EAP tests
        | JGROUPS_PING_PROTOCOL                        | dns.DNS_PING                            |
        | OPENSHIFT_DNS_PING_SERVICE_NAME              | ping-service                            |
        | JGROUPS_CLUSTER_PASSWORD                     | P@ssw0rd                                |
-    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keysore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keystore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
 
   @redhat-sso-7-tech-preview/sso-cd-openshift @redhat-sso-7/sso73-openshift
   Scenario: Check jgroups encryption issues a warning when using ASYM_ENCRYPT with JGROUPS_ENCRYPT_KEYSTORE file defined
@@ -211,7 +211,7 @@ Feature: Common EAP tests
        | JGROUPS_PING_PROTOCOL                        | dns.DNS_PING                            |
        | OPENSHIFT_DNS_PING_SERVICE_NAME              | ping-service                            |
        | JGROUPS_CLUSTER_PASSWORD                     | P@ssw0rd                                |
-    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keysore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
+    Then container log should contain WARN Detected partial JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keystore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
   # CD doesn't have these any more
   @ignore @jboss-eap-7-tech-preview
   Scenario: No duplicate module jars

--- a/tests/features/jgroups.feature
+++ b/tests/features/jgroups.feature
@@ -154,7 +154,7 @@ Scenario: Verify configuration jgroups deprecated ASYM_ENCRYPT, kubernetes.KUBE_
        | JGROUPS_ENCRYPT_PROTOCOL                     | ASYM_ENCRYPT          |
        | JGROUPS_CLUSTER_PASSWORD                     | P@assw0rd             |
     Then container log should contain WFLYSRV0025:
-     And container log should contain WARN Detected missing JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keysore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
+     And container log should contain WARN Detected missing JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keystore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='kubernetes.KUBE_PING']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='org.jgroups.protocols.ASYM_ENCRYPT']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='auth-protocol'][@type='AUTH']
@@ -188,7 +188,7 @@ Scenario: Verify configuration jgroups deprecated ASYM_ENCRYPT, dns.DNS_PING pin
        | JGROUPS_CLUSTER_PASSWORD                     | P@assw0rd                              |
        | JGROUPS_PING_PROTOCOL                        | dns.DNS_PING                           |
     Then container log should contain WFLYSRV0025:
-     And container log should contain WARN Detected missing JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keysore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
+     And container log should contain WARN Detected missing JGroups encryption configuration, the communication within the cluster will be encrypted using a deprecated version of ASYM_ENCRYPT protocol. You need to set all of these variables to configure ASYM_ENCRYPT using the Elytron keystore: JGROUPS_ENCRYPT_SECRET, JGROUPS_ENCRYPT_NAME, JGROUPS_ENCRYPT_PASSWORD, JGROUPS_ENCRYPT_KEYSTORE.
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='dns.DNS_PING']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='org.jgroups.protocols.ASYM_ENCRYPT']
      And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='auth-protocol'][@type='AUTH']


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-20733
Upstream Issue: https://issues.redhat.com/browse/CLOUD-3509
Upstream PR: https://github.com/jboss-container-images/jboss-eap-modules/pull/184