### PR TITLE
CLOUD-3918 - EAP 7.4.0.Beta images

### DIFF
--- a/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/pom.xml
+++ b/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/pom.xml
@@ -43,7 +43,7 @@
     <dependencies>
         <dependency>
             <groupId>${full.maven.groupId}</groupId>
-            <artifactId>wildfly-galleon-pack</artifactId>
+            <artifactId>wildfly-ee-galleon-pack</artifactId>
             <version>${version.org.wildfly}</version>
             <type>zip</type>
         </dependency>

--- a/jboss/container/eap/prometheus/config/module.yaml
+++ b/jboss/container/eap/prometheus/config/module.yaml
@@ -9,5 +9,5 @@ execute:
 
 modules:
   install:
-  - name: jboss.container.prometheus.bash
+  - name: jboss.container.prometheus
   - name: jboss.container.eap.prometheus.jmx-exporter-config

--- a/jboss/container/eap/prometheus/runtime/module.yaml
+++ b/jboss/container/eap/prometheus/runtime/module.yaml
@@ -5,5 +5,5 @@ description: Provides Prometheus JMX Exporter configuration and agent
 
 modules:
   install:
-  - name: jboss.container.prometheus.bash
+  - name: jboss.container.prometheus
   - name: jboss.container.eap.prometheus.jmx-exporter-config


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-3918
Signed-off-by: Ken Wills <kwills@redhat.com>

Note this change reflects the corresponding change in cct_module v0.44.0 and is required to use cct_module moving forwards.