### PR TITLE
Fix for CLOUD-3918, EAP 7.4.0.Beta OpenShift images, remove microprofile scripts

### DIFF
--- a/jboss/container/eap/launch/added/launch/launch-config.sh
+++ b/jboss/container/eap/launch/added/launch/launch-config.sh
@@ -28,8 +28,6 @@ CONFIG_SCRIPT_CANDIDATES=(
   $JBOSS_HOME/bin/launch/deploymentScanner.sh
   $JBOSS_HOME/bin/launch/ports.sh
   $JBOSS_HOME/bin/launch/access_log_valve.sh
-  $JBOSS_HOME/bin/launch/mp-config.sh
-  $JBOSS_HOME/bin/launch/tracing.sh
   $JBOSS_HOME/bin/launch/filters.sh
   $JBOSS_HOME/bin/launch/statefulset.sh
   /opt/run-java/proxy-options


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3918
Remove the scripts that are no more present in the image.