### PR TITLE
[CLOUD-3920] Add a timestamp at the beginning of image startup in EAP images

### DIFF
--- a/jboss/container/eap/launch/added/openshift-launch.sh
+++ b/jboss/container/eap/launch/added/openshift-launch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "`date "+%Y-%m-%d %H:%M:%S"` Launching EAP Server"
+
 # Always start sourcing the launch script supplied by wildfly-cekit-modules
 source ${JBOSS_HOME}/bin/launch/launch.sh
 


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CLOUD-3920
Related (cloned) issue: https://issues.redhat.com/browse/JBEAP-18005

Upstream PR: https://github.com/wildfly/wildfly-s2i/pull/147