### PR TITLE
Shorten target values in order to build through cpaas

### DIFF
--- a/jboss/container/eap/openshift/modules/module.yaml
+++ b/jboss/container/eap/openshift/modules/module.yaml
@@ -8,8 +8,8 @@ execute:
 
 artifacts:
 - name: txn-recovery-marker-jdbc-common
-  target: txn-recovery-marker-jdbc-common-1.1.4.Final-redhat-00001.jar
+  target: txn-1.1.4.Final-redhat-00001.jar
   md5: 305aa706018b1089e5b82528b601541f
 - name: txn-recovery-marker-jdbc-hibernate5
-  target: txn-recovery-marker-jdbc-hibernate5-1.1.4.Final-redhat-00001.jar
+  target: txn-1.1.4.Final-redhat-00001.jar
   md5: 99f2a2e68fb92273b8016e2b199fbd91


### PR DESCRIPTION
Cpaas might have a constraint for longer strings for some values.

This PR intends to shorten the lenght of some values in order to build on cpaas.