### PR TITLE
[EAP 7.4.0][CLOUD-3954]Update versions to 23

### DIFF
--- a/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/pom.xml
+++ b/jboss/container/eap/galleon/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jboss.eap.galleon.s2i</groupId>
     <artifactId>eap-s2i-galleon-pack</artifactId>
-    <version>21.0.0.Final</version>
+    <version>23.0.0.Final</version>
     <packaging>pom</packaging>
     <name>EAP Galleon feature-pack for OpenShift</name>
 

--- a/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/definitions/fat-default-server/provisioning.xml
+++ b/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/definitions/fat-default-server/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- Use the image version,  to avoid retrieving metadata.xml for un-released s2i FP-->
-    <feature-pack location="eap-s2i@maven(org.jboss.universe:s2i-universe)#21.0.0.Final">
+    <feature-pack location="eap-s2i@maven(org.jboss.universe:s2i-universe)#23.0.0.Final">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>

--- a/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/definitions/slim-default-server/provisioning.xml
+++ b/jboss/container/eap/galleon/config/ee/artifacts/opt/jboss/container/eap/galleon/definitions/slim-default-server/provisioning.xml
@@ -2,7 +2,7 @@
 
 <installation xmlns="urn:jboss:galleon:provisioning:3.0">
     <!-- Use the image version,  to avoid retrieving metadata.xml for un-released s2i FP-->
-    <feature-pack location="eap-s2i@maven(org.jboss.universe:s2i-universe)#21.0.0.Final">
+    <feature-pack location="eap-s2i@maven(org.jboss.universe:s2i-universe)#23.0.0.Final">
         <default-configs inherit="false">
             <include model="standalone" name="standalone.xml"/>
         </default-configs>

--- a/jboss/container/eap/galleon/module.yaml
+++ b/jboss/container/eap/galleon/module.yaml
@@ -5,7 +5,7 @@ description: Install Galleon descriptions and EAP s2i feature-pack. Configure ga
 
 envs:
 - name: S2I_FP_VERSION
-  value: "21.0.0.Final"
+  value: "23.0.0.Final"
 - name: GALLEON_DEFINITIONS
   value: /opt/jboss/container/eap/galleon/definitions
 - name: GALLEON_MAVEN_REPO_HOOK_SCRIPT


### PR DESCRIPTION
Until know we have used the WF major version internally for the s2i galleon fp.

https://issues.redhat.com/browse/CLOUD-3954