### PR TITLE
[EAP 7.4.0] [CLOUD-3949], ignore microprofile related tests

### DIFF
--- a/tests/features/galleon.feature
+++ b/tests/features/galleon.feature
@@ -1,6 +1,8 @@
 @jboss-eap-7 @jboss-eap-7-tech-preview
 Feature: Openshift EAP galleon s2i tests
 
+# CLOUD-3949
+@ignore 
   Scenario: Test microprofile config.
     Given s2i build git://github.com/openshift/openshift-jee-sample from . with env and true using master
       | variable                             | value         |
@@ -258,6 +260,8 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value cloud-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value observability on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='exclude']/@name
 
+# CLOUD-3949
+@ignore 
   Scenario: Test cloud-server, exclude open-tracing
     Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs with env and true
       | variable                             | value         |
@@ -270,11 +274,15 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value cloud-server on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value open-tracing on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='exclude']/@name
 
+# CLOUD-3949
+@ignore 
   Scenario: Test cloud-server, exclude open-tracing and observability
     Given failing s2i build git://github.com/openshift/openshift-jee-sample from . using master
       | variable                             | value         |
       | GALLEON_PROVISION_LAYERS             | cloud-server,-open-tracing,-observability  |
 
+# CLOUD-3949
+@ignore 
   Scenario: Test jaxrs-server+observability, exclude open-tracing
     Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs with env and true
       | variable                             | value         |
@@ -288,6 +296,8 @@ Feature: Openshift EAP galleon s2i tests
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value observability on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='include']/@name
     Then XML file /opt/eap/.galleon/provisioning.xml should contain value open-tracing on XPath //*[local-name()='installation']/*[local-name()='config']/*[local-name()='layers']/*[local-name()='exclude']/@name
 
+# CLOUD-3949
+@ignore 
   Scenario: Test jaxrs-server+observability, exclude open-tracing from provisioning.xml
     Given s2i build git://github.com/jboss-container-images/jboss-eap-modules from tests/examples/test-app-jaxrs-exclude with env and true
     Then container log should contain WFLYSRV0025

--- a/tests/features/mp-config.feature
+++ b/tests/features/mp-config.feature
@@ -1,3 +1,5 @@
+# CLOUD-3949
+@ignore 
 @jboss-eap-7 @jboss-eap-7-tech-preview
 Feature: EAP Openshift mp-config tests
 

--- a/tests/features/tracing.feature
+++ b/tests/features/tracing.feature
@@ -1,3 +1,5 @@
+# CLOUD-3949
+@ignore 
 @jboss-eap-7 @jboss-eap-7-tech-preview
 Feature: EAP Openshift open-tracing tests
 


### PR DESCRIPTION
These tests can't pass with EAP 7.4.0, they should be removed and moved to XP3 tests. For now they are ignored.