### PR TITLE
[CLOUD-4021] dot is not permitted in tx datasource table name, test adjustment

### DIFF
--- a/tests/features/datasource-tx.feature
+++ b/tests/features/datasource-tx.feature
@@ -135,7 +135,7 @@ Feature: EAP Openshift transaction objectstore datasources
       | TEST_NONXA                     | true                                   |
       | TEST_JTA                       | false                                  |
       | JDBC_STORE_JNDI_NAME           | java:/jboss/datasources/testds         |
-      | NODE_NAME                      | Test-Store-Node-Name                   |
+      | NODE_NAME                      | Test-Store-Node.Name                   |
       | JDBC_SKIP_RECOVERY             | true                                   |
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testds on XPath //*[local-name()='datasource']/@jndi-name
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jdbc:postgresql://10.1.1.1:5432/pgdb on XPath //*[local-name()='datasource']/*[local-name()='connection-url']
@@ -160,7 +160,7 @@ Feature: EAP Openshift transaction objectstore datasources
       | TEST_DATABASE                  | XE                                     |
       | TEST_NONXA                     | false                                  |
       | TEST_JTA                       | true                                   |
-      | NODE_NAME                      | TestStoreNodeName                      |
+      | NODE_NAME                      | Test.Store-Node.Name                   |
       | JDBC_SKIP_RECOVERY             | true                                   |
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value java:/jboss/datasources/testdsObjectStore on XPath //*[local-name()='datasource']/@jndi-name
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value testObjectStorePool on XPath //*[local-name()='datasource']/@pool-name


### PR DESCRIPTION
https://issues.redhat.com/browse/CLOUD-4021
https://issues.redhat.com/browse/EAPSUP-592

requires changes in cekit moduels: https://github.com/wildfly/wildfly-cekit-modules/pull/257