### PR TITLE
[JBEAP-22439] Revert "CLOUD-4005 - EAP XP 3.0 - Wrong S2I_FP_VERSION"

### DIFF
--- a/jboss/container/eap/galleon/module.yaml
+++ b/jboss/container/eap/galleon/module.yaml
@@ -5,7 +5,7 @@ description: Install Galleon descriptions and EAP s2i feature-pack. Configure ga
 
 envs:
 - name: S2I_FP_VERSION
-  value: "3.0.0.Final"
+  value: "23.0.0.Final"
 - name: GALLEON_DEFINITIONS
   value: /opt/jboss/container/eap/galleon/definitions
 - name: GALLEON_MAVEN_REPO_HOOK_SCRIPT


### PR DESCRIPTION
This reverts commit 7771f7eddff4c8ac5508e28e78f426170723260f.

S2I_FP_VERSION should be 23.0.0.Final, which is the Wildfly version that 7.4.0.GA was
based on.