### PR TITLE
Update acivemq.rar to pull from brew, not MRRC

### DIFF
--- a/os-eap-activemq-rar/module.yaml
+++ b/os-eap-activemq-rar/module.yaml
@@ -7,5 +7,6 @@ execute:
   user: '185'
 
 artifacts:
-- url: https://maven.repository.redhat.com/ga/org/apache/activemq/activemq-rar/5.11.0.redhat-630495/activemq-rar-5.11.0.redhat-630495.rar
+- name: activemq-rar-5.11.0.redhat-630495.rar
+  target: activemq-rar-5.11.0.redhat-630495.rar
   md5: 4bb3ccb1a3732a21435e36858c913699


### PR DESCRIPTION
Note, MRRC is not available during builds, so artifacts like this need to come from brew. (This only appears to affect new build repos.)
Signed-off-by: Ken Wills <kwills@redhat.com>