### PR TITLE
Add module to install tzdata-java

### DIFF
--- a/jboss/container/eap/tzdata-java/module.yaml
+++ b/jboss/container/eap/tzdata-java/module.yaml
@@ -1,0 +1,8 @@
+schema_version: 1
+name: jboss.container.eap.tzdata-java
+version: '1.0'
+description:  "Install tzdata-java"
+
+packages:
+  install:
+  - tzdata-java


### PR DESCRIPTION
Issue: https://access.redhat.com/solutions/7025428

tzdata-java is not part of JDK 11.0.20

Signed-off-by: Ruben Dario Novelli [rnovelli@redhat.com](mailto:rnovelli@redhat.com)