### PR TITLE
Fix for JBEAP-24017, [7.4.* JDK 17 images] - Missing required KEYCLOAK mechanism

### DIFF
--- a/jboss/container/eap/galleon/config/ee-elytron/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
+++ b/jboss/container/eap/galleon/config/ee-elytron/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone.xml/config.xml
@@ -9,8 +9,7 @@
         <include name="amq6-rar"/>
     </layers>
 
-     <!-- No sso packages for JDK17 techpreview -->
-    <!-- <feature-group name="sso"/> -->
+    <feature-group name="sso"/>
 
     <!-- JDK 17 -->
     <exclude feature-id="core-service.management.security-realm:security-realm=ApplicationRealm"/>

--- a/jboss/container/eap/galleon/config/ee-elytron/configure.sh
+++ b/jboss/container/eap/galleon/config/ee-elytron/configure.sh
@@ -11,7 +11,3 @@ chmod -R ug+rwX $SCRIPT_DIR
 pushd ${ARTIFACTS_DIR}
 cp -pr * /
 popd
-
-# Remove sso content for JDK17 tech preview image. To be removed when supported.
-rm "${GALLEON_FP_PATH}/src/main/resources/feature_groups/sso.xml"
-rm -r "${GALLEON_FP_PATH}/src/main/resources/layers/standalone/sso"

--- a/jboss/container/eap/galleon/config/mp-elytron/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone-microprofile-ha.xml/config.xml
+++ b/jboss/container/eap/galleon/config/mp-elytron/artifacts/opt/jboss/container/eap/galleon/eap-s2i-galleon-pack/src/main/resources/configs/standalone/standalone-microprofile-ha.xml/config.xml
@@ -4,7 +4,7 @@
 
     
     <!-- sso packages -->
-    <!--<feature-group name="sso"/>-->
+    <feature-group name="sso"/>
 
     <!-- JDK17. The default standalone-microprofile-ha.xml is secured with legacy security realm for the http-invoker. Use elytron. -->
     <feature spec="subsystem.undertow">


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBEAP-24017
The fix applies to both EAP 7.4.x and XP4 images.